### PR TITLE
feat: cross-language crypto test vectors and Node SDK modernization

### DIFF
--- a/docs/cross_test_plan.md
+++ b/docs/cross_test_plan.md
@@ -1,0 +1,43 @@
+# Plan: Add cross-test vector tests to Go, Python, and Java
+
+## Context
+Only Node loads `cross_test/test_vectors.json`. Go, Python, and Java hardcode equivalent values. Adding vector-file-based tests to all platforms ensures crypto compatibility can be verified per-language before release, without running cross-language integration tests.
+
+## What the vectors test
+The vectors file contains: Keccak256 hashes, key derivation (private → public), and request hash (body + timestamp → digest). It does **not** contain expected signatures (ECDSA is non-deterministic without RFC 6979), so signing tests will do sign + verify round-trips.
+
+## Changes
+
+### 1. Go — `go/crypto/cross_test.go` (new file)
+- Load `../../cross_test/test_vectors.json` via `os.ReadFile`
+- Test Keccak256 hashes match vectors
+- Test `NewSignerFromHex` derives correct public key
+- Test request hash computation (body + LE timestamp)
+- Test sign + verify round-trip using vector key + hash
+- Use `testing` + `testify/require` (existing pattern)
+
+### 2. Python — `python/sdk/tests/crypto/test_cross_vectors.py` (new file)
+- Load `../../../../cross_test/test_vectors.json` via `json.load`
+- Test `legacy_keccak256` matches vector hashes
+- Test `new_signer_from_hex` derives correct public key
+- Test request hash computation
+- Test sign + verify round-trip
+- Use `pytest` (existing pattern)
+
+### 3. Java — `java/sdk/src/test/java/network/t0/sdk/crypto/CrossVectorTest.java` (new file)
+- Load vectors from classpath or relative path via `getClass().getResourceAsStream()` or `Paths.get()`
+- Test `Keccak256.hash()` matches vector hashes
+- Test `Signer.fromHex()` derives correct public key
+- Test request hash (body bytes + LE 8-byte timestamp)
+- Test sign + verify round-trip
+- Use JUnit 5 + AssertJ (existing pattern)
+
+### 4. Node — no changes needed (already uses vectors)
+
+## Verification
+```bash
+cd go && go test ./crypto/... -run Cross
+cd python && uv run pytest python/sdk/tests/crypto/test_cross_vectors.py -v
+cd java && ./gradlew test --tests "*CrossVector*"
+cd node/sdk && npm test
+```

--- a/go/crypto/cross_test.go
+++ b/go/crypto/cross_test.go
@@ -1,0 +1,84 @@
+package crypto_test
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/t-0-network/provider-sdk/go/crypto"
+)
+
+type testVectors struct {
+	Keys struct {
+		PrivateKey string `json:"private_key"`
+		PublicKey  string `json:"public_key"`
+	} `json:"keys"`
+	Keccak256 []struct {
+		Input string `json:"input"`
+		Hash  string `json:"hash"`
+	} `json:"keccak256"`
+	RequestSigning struct {
+		Body         string `json:"body"`
+		TimestampMs  uint64 `json:"timestamp_ms"`
+		ExpectedHash string `json:"expected_hash"`
+	} `json:"request_signing"`
+}
+
+func loadVectors(t *testing.T) testVectors {
+	t.Helper()
+	data, err := os.ReadFile("../../cross_test/test_vectors.json")
+	require.NoError(t, err, "failed to read test vectors")
+	var v testVectors
+	require.NoError(t, json.Unmarshal(data, &v))
+	return v
+}
+
+func TestCrossVectors_Keccak256(t *testing.T) {
+	v := loadVectors(t)
+	for _, tc := range v.Keccak256 {
+		t.Run(tc.Input, func(t *testing.T) {
+			hash := crypto.LegacyKeccak256([]byte(tc.Input))
+			require.Equal(t, tc.Hash, hex.EncodeToString(hash))
+		})
+	}
+}
+
+func TestCrossVectors_KeyDerivation(t *testing.T) {
+	v := loadVectors(t)
+	sign, err := crypto.NewSignerFromHex(v.Keys.PrivateKey)
+	require.NoError(t, err)
+
+	digest := crypto.LegacyKeccak256([]byte("test"))
+	_, pubKeyBytes, err := sign(digest)
+	require.NoError(t, err)
+	require.Equal(t, v.Keys.PublicKey, hex.EncodeToString(pubKeyBytes))
+}
+
+func TestCrossVectors_RequestHash(t *testing.T) {
+	v := loadVectors(t)
+
+	body := []byte(v.RequestSigning.Body)
+	tsBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(tsBytes, v.RequestSigning.TimestampMs)
+
+	combined := append(body, tsBytes...)
+	hash := crypto.LegacyKeccak256(combined)
+	require.Equal(t, v.RequestSigning.ExpectedHash, hex.EncodeToString(hash))
+}
+
+func TestCrossVectors_SignVerifyRoundTrip(t *testing.T) {
+	v := loadVectors(t)
+	sign, err := crypto.NewSignerFromHex(v.Keys.PrivateKey)
+	require.NoError(t, err)
+
+	digest := crypto.LegacyKeccak256([]byte("round trip test"))
+	signature, pubKeyBytes, err := sign(digest)
+	require.NoError(t, err)
+
+	pubKey, err := crypto.GetPublicKeyFromBytes(pubKeyBytes)
+	require.NoError(t, err)
+	require.True(t, crypto.VerifySignature(pubKey, digest, signature))
+}

--- a/go/starter/template/go.sum
+++ b/go/starter/template/go.sum
@@ -22,6 +22,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/t-0-network/provider-sdk/go v1.1.6/go.mod h1:fPfYQli7B3XYG+DjjO5cVnFZzAmCDOse/HtvugDWe4c=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=

--- a/java/sdk/build.gradle.kts
+++ b/java/sdk/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     compileOnly("javax.annotation:javax.annotation-api:1.3.2")
 
     // Testing
+    testImplementation("com.google.code.gson:gson:2.12.1")
     testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
     testImplementation("org.assertj:assertj-core:3.27.7")
     testImplementation("io.grpc:grpc-testing:$grpcVersion")

--- a/java/sdk/src/test/java/network/t0/sdk/crypto/CrossVectorTest.java
+++ b/java/sdk/src/test/java/network/t0/sdk/crypto/CrossVectorTest.java
@@ -1,0 +1,88 @@
+package network.t0.sdk.crypto;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import network.t0.sdk.common.HexUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests using shared cross-language test vectors from cross_test/test_vectors.json.
+ */
+class CrossVectorTest {
+
+    private static JsonObject vectors;
+
+    @BeforeAll
+    static void loadVectors() throws IOException {
+        // Gradle runs tests with CWD = project root (java/sdk/)
+        Path vectorsPath = Path.of("../../cross_test/test_vectors.json");
+        String json = Files.readString(vectorsPath);
+        vectors = JsonParser.parseString(json).getAsJsonObject();
+    }
+
+    @Test
+    void keccak256_shouldMatchAllVectors() {
+        JsonArray keccakVectors = vectors.getAsJsonArray("keccak256");
+        for (var element : keccakVectors) {
+            JsonObject vec = element.getAsJsonObject();
+            String input = vec.get("input").getAsString();
+            String expectedHash = vec.get("hash").getAsString();
+
+            byte[] hash = Keccak256.hash(input.getBytes());
+            assertThat(HexUtils.bytesToHex(hash))
+                    .as("Keccak256 of \"%s\"", input)
+                    .isEqualTo(expectedHash);
+        }
+    }
+
+    @Test
+    void keyDerivation_shouldMatchVectorPublicKey() {
+        JsonObject keys = vectors.getAsJsonObject("keys");
+        String privateKeyHex = keys.get("private_key").getAsString();
+        String expectedPublicKeyHex = keys.get("public_key").getAsString();
+
+        Signer signer = Signer.fromHex(privateKeyHex);
+        assertThat(HexUtils.bytesToHex(signer.getPublicKey()))
+                .isEqualTo(expectedPublicKeyHex);
+    }
+
+    @Test
+    void requestHash_shouldMatchExpected() {
+        JsonObject rs = vectors.getAsJsonObject("request_signing");
+        String body = rs.get("body").getAsString();
+        long timestampMs = rs.get("timestamp_ms").getAsLong();
+        String expectedHash = rs.get("expected_hash").getAsString();
+
+        byte[] tsBytes = ByteBuffer.allocate(8)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putLong(timestampMs)
+                .array();
+
+        byte[] hash = Keccak256.hash(body.getBytes(), tsBytes);
+        assertThat(HexUtils.bytesToHex(hash)).isEqualTo(expectedHash);
+    }
+
+    @Test
+    void signVerifyRoundTrip_shouldSucceed() {
+        JsonObject keys = vectors.getAsJsonObject("keys");
+        String privateKeyHex = keys.get("private_key").getAsString();
+
+        Signer signer = Signer.fromHex(privateKeyHex);
+        byte[] digest = Keccak256.hash("round trip test".getBytes());
+
+        SignResult result = signer.sign(digest);
+        boolean valid = SignatureVerifier.verify(
+                signer.getPublicKey(), digest, result.getSignature());
+        assertThat(valid).isTrue();
+    }
+}

--- a/node/sdk/package-lock.json
+++ b/node/sdk/package-lock.json
@@ -12,8 +12,8 @@
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-node": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
-        "@noble/hashes": "^2.0.1",
-        "@noble/secp256k1": "^2.3.0"
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1"
       },
       "devDependencies": {
         "@bufbuild/protoc-gen-es": "^2.11.0",
@@ -554,6 +554,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
@@ -562,15 +577,6 @@
       "engines": {
         "node": ">= 20.19.0"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/secp256k1": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-2.3.0.tgz",
-      "integrity": "sha512-0TQed2gcBbIrh7Ccyw+y/uZQvbJwm7Ao4scBUxqpBCcsOlZG0O4KGfjtNAy/li4W8n1xt3dxrwJ0beZ2h2G6Kw==",
-      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }

--- a/node/sdk/package.json
+++ b/node/sdk/package.json
@@ -32,8 +32,8 @@
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-web": "^2.1.1",
     "@connectrpc/connect-node": "^2.1.1",
-    "@noble/hashes": "^2.0.1",
-    "@noble/secp256k1": "^2.3.0"
+    "@noble/curves": "^2.0.1",
+    "@noble/hashes": "^2.0.1"
   },
   "devDependencies": {
     "@bufbuild/protoc-gen-es": "^2.11.0",

--- a/node/sdk/src/client/signer.ts
+++ b/node/sdk/src/client/signer.ts
@@ -1,9 +1,9 @@
-import * as secp from '@noble/secp256k1'
+import { secp256k1 } from '@noble/curves/secp256k1.js'
 import {Signature} from "./client.js";
 
 export const CreateSigner = (privateKey: string | Buffer)=> {
     privateKey = parsePrivateKey(privateKey)
-    const publicKey = Buffer.from(secp.getPublicKey(privateKey, false));
+    const publicKey = Buffer.from(secp256k1.getPublicKey(privateKey, false));
 
     return async (data: Buffer): Promise<Signature> => {
         // Ensure hash is 32 bytes
@@ -12,10 +12,10 @@ export const CreateSigner = (privateKey: string | Buffer)=> {
         }
 
         // Sign the hash
-        const signature = await secp.signAsync(data, privateKey);
+        const signature = secp256k1.sign(data, privateKey);
 
         return {
-            signature: Buffer.from(signature.toBytes()),
+            signature: Buffer.from(signature),
             publicKey: publicKey,
         };
     }
@@ -32,7 +32,7 @@ const parsePrivateKey = (privateKey: string | Buffer) => {
     }
 
     // Validate private key
-    if (!secp.utils.isValidPrivateKey(privateKey)) {
+    if (!secp256k1.utils.isValidSecretKey(privateKey)) {
         throw new Error('Invalid private key');
     }
 

--- a/node/sdk/src/service/service.ts
+++ b/node/sdk/src/service/service.ts
@@ -9,7 +9,7 @@ import {
 } from "@connectrpc/connect";
 import type { Interceptor } from "@connectrpc/connect";
 import NetworkHeaders from "../common/headers.js";
-import * as secp from '@noble/secp256k1'
+import { secp256k1 } from '@noble/curves/secp256k1.js'
 import {Hash} from "@noble/hashes/utils.js";
 import type {DescService, } from "@bufbuild/protobuf";
 import type {ServiceImpl} from "@connectrpc/connect";
@@ -42,7 +42,7 @@ const createSignatureVerification: (networkPublicKey: Buffer) => Interceptor = (
     .digest();
   let signatureValid = false;
   try {
-    signatureValid = secp.verify(signature, hash, publicKey);
+    signatureValid = secp256k1.verify(signature, hash, publicKey);
   } catch (e) {
     throw new ConnectError(`${NetworkHeaders.Signature} has invalid signature or public key format: ${e}` , Code.Unauthenticated);
   }

--- a/node/starter/package-lock.json
+++ b/node/starter/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
+        "commander": "^13.1.0",
         "fs-extra": "^11.3.4",
         "inquirer": "^13.3.0"
       },
@@ -428,6 +429,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-string-truncated-width": {

--- a/node/starter/package.json
+++ b/node/starter/package.json
@@ -31,6 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^5.6.2",
+    "commander": "^13.1.0",
     "fs-extra": "^11.3.4",
     "inquirer": "^13.3.0"
   },

--- a/node/starter/src/create.ts
+++ b/node/starter/src/create.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { execSync } from 'child_process';
+import { Command } from 'commander';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 
@@ -9,15 +10,18 @@ interface KeyPair {
   publicKey: string;
 }
 
-interface ProjectAnswers {
-  projectName: string;
+function validateProjectName(name: string): string {
+  if (!/^[a-z0-9-_]+$/.test(name)) {
+    console.error(chalk.red(
+      '\n❌ Project name can only contain lowercase letters, numbers, hyphens and underscores'
+    ));
+    process.exit(1);
+  }
+  return name;
 }
 
-async function create(): Promise<void> {
-  console.log(chalk.blue('\n🚀 Create Your Service\n'));
-
-  // Prompt for project name
-  const answers = await inquirer.prompt<ProjectAnswers>([
+async function promptProjectName(): Promise<string> {
+  const answers = await inquirer.prompt<{ projectName: string }>([
     {
       type: 'input',
       name: 'projectName',
@@ -31,35 +35,52 @@ async function create(): Promise<void> {
       }
     }
   ]);
+  return answers.projectName;
+}
 
-  const projectName = answers.projectName;
-  const projectPath = path.join(process.cwd(), projectName);
+async function create(): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const packageJson = require('../package.json');
 
-  // Check if directory exists
-  if (fs.existsSync(projectPath)) {
-    console.log(chalk.red(`\n❌ Directory "${projectName}" already exists!`));
-    process.exit(1);
-  }
+  const program = new Command()
+    .name('provider-starter-ts')
+    .description('Scaffold a Node.js t-0 Network integration service')
+    .version(packageJson.version)
+    .argument('[project-name]', 'Name for the new project')
+    .action(async (projectNameArg?: string) => {
+      console.log(chalk.blue('\n🚀 Create Your Service\n'));
 
-  console.log(chalk.green(`\n✨ Creating project in ${projectPath}...\n`));
+      const projectName = projectNameArg
+        ? validateProjectName(projectNameArg)
+        : await promptProjectName();
 
-  try {
-    // Create project directory
-    fs.mkdirSync(projectPath);
+      const projectPath = path.join(process.cwd(), projectName);
 
-    // Copy template files
-    const templatePath = path.join(__dirname, '../template');
-    fs.copySync(templatePath, projectPath);
+      // Check if directory exists
+      if (fs.existsSync(projectPath)) {
+        console.log(chalk.red(`\n❌ Directory "${projectName}" already exists!`));
+        process.exit(1);
+      }
 
-    // Generate key pair
-    console.log(chalk.cyan('🔐 Generating key pair...'));
-    const keys = generateKeyPair();
+      console.log(chalk.green(`\n✨ Creating project in ${projectPath}...\n`));
 
-    // Create .env file with keys
-    const envContent = `
+      try {
+        // Create project directory
+        fs.mkdirSync(projectPath);
+
+        // Copy template files
+        const templatePath = path.join(__dirname, '../template');
+        fs.copySync(templatePath, projectPath);
+
+        // Generate key pair
+        console.log(chalk.cyan('🔐 Generating key pair...'));
+        const keys = generateKeyPair();
+
+        // Create .env file with keys
+        const envContent = `
 NETWORK_PUBLIC_KEY=0x041b6acf3e830b593aaa992f2f1543dc8063197acfeecefd65135259327ef3166acaca83d62db19eb4fecb3d04e44094378839b8c13a2af26bf78fed56a4af935b
 
-# Private Key (secp256k1)    
+# Private Key (secp256k1)
 PROVIDER_PRIVATE_KEY=${keys.privateKey}
 # TODO: Step 1.2 Share this Public Key with t-0 team
 # ${keys.publicKey}
@@ -71,16 +92,16 @@ NODE_ENV=development
 # QUOTE_PUBLISHING_INTERVAL=5000
 
 `;
-    fs.writeFileSync(path.join(projectPath, '.env'), envContent);
+        fs.writeFileSync(path.join(projectPath, '.env'), envContent);
 
-    // Update package.json with project name
-    const packageJsonPath = path.join(projectPath, 'package.json');
-    let packageJson = fs.readFileSync(packageJsonPath, 'utf8');
-    packageJson = packageJson.replace('{{PROJECT_NAME}}', projectName);
-    fs.writeFileSync(packageJsonPath, packageJson);
+        // Update package.json with project name
+        const pkgJsonPath = path.join(projectPath, 'package.json');
+        let pkgJson = fs.readFileSync(pkgJsonPath, 'utf8');
+        pkgJson = pkgJson.replace('{{PROJECT_NAME}}', projectName);
+        fs.writeFileSync(pkgJsonPath, pkgJson);
 
-    // Create .gitignore
-    const gitignoreContent = `node_modules/
+        // Create .gitignore
+        const gitignoreContent = `node_modules/
 dist/
 .env
 .env.local
@@ -88,29 +109,32 @@ dist/
 *.log
 .DS_Store
 `;
-    fs.writeFileSync(path.join(projectPath, '.gitignore'), gitignoreContent);
+        fs.writeFileSync(path.join(projectPath, '.gitignore'), gitignoreContent);
 
-    // Git init
-    console.log(chalk.cyan('📦 Initializing git repository...'));
-    execSync('git init', { cwd: projectPath, stdio: 'ignore' });
+        // Git init
+        console.log(chalk.cyan('📦 Initializing git repository...'));
+        execSync('git init', { cwd: projectPath, stdio: 'ignore' });
 
-    // npm install
-    console.log(chalk.cyan('📥 Installing dependencies...'));
-    execSync('npm install', { cwd: projectPath, stdio: 'inherit' });
+        // npm install
+        console.log(chalk.cyan('📥 Installing dependencies...'));
+        execSync('npm install', { cwd: projectPath, stdio: 'inherit' });
 
-    console.log(chalk.green('\n✅ Project created successfully!\n'));
-    console.log(chalk.white(`  cd ${projectName}`));
-    console.log(chalk.white(`  npm run dev\n`));
+        console.log(chalk.green('\n✅ Project created successfully!\n'));
+        console.log(chalk.white(`  cd ${projectName}`));
+        console.log(chalk.white(`  npm run dev\n`));
 
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    console.error(chalk.red('\n❌ Error creating project:'), errorMessage);
-    // Cleanup on error
-    if (fs.existsSync(projectPath)) {
-      //fs.removeSync(projectPath);
-    }
-    process.exit(1);
-  }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        console.error(chalk.red('\n❌ Error creating project:'), errorMessage);
+        // Cleanup on error
+        if (fs.existsSync(projectPath)) {
+          fs.removeSync(projectPath);
+        }
+        process.exit(1);
+      }
+    });
+
+  await program.parseAsync(process.argv);
 }
 
 function generateKeyPair(): KeyPair {

--- a/python/sdk/tests/crypto/test_cross_vectors.py
+++ b/python/sdk/tests/crypto/test_cross_vectors.py
@@ -1,0 +1,53 @@
+"""Tests using shared cross-language test vectors."""
+
+import json
+import struct
+from pathlib import Path
+
+from t0_provider_sdk.crypto.hash import legacy_keccak256
+from t0_provider_sdk.crypto.keys import public_key_from_bytes
+from t0_provider_sdk.crypto.signer import new_signer_from_hex
+from t0_provider_sdk.crypto.verifier import verify_signature
+
+VECTORS_PATH = Path(__file__).resolve().parents[4] / "cross_test" / "test_vectors.json"
+
+
+def _load_vectors():
+    with open(VECTORS_PATH) as f:
+        return json.load(f)
+
+
+VECTORS = _load_vectors()
+
+
+class TestCrossVectorsKeccak256:
+    def test_all_vectors(self):
+        for vec in VECTORS["keccak256"]:
+            result = legacy_keccak256(vec["input"].encode())
+            assert result.hex() == vec["hash"], f"failed for input: {vec['input']!r}"
+
+
+class TestCrossVectorsKeyDerivation:
+    def test_public_key_matches(self):
+        sign_fn = new_signer_from_hex(VECTORS["keys"]["private_key"])
+        digest = legacy_keccak256(b"test")
+        _sig, pub_key_bytes = sign_fn(digest)
+        assert pub_key_bytes.hex() == VECTORS["keys"]["public_key"]
+
+
+class TestCrossVectorsRequestHash:
+    def test_body_plus_timestamp(self):
+        rs = VECTORS["request_signing"]
+        body = rs["body"].encode()
+        ts_bytes = struct.pack("<Q", rs["timestamp_ms"])
+        digest = legacy_keccak256(body + ts_bytes)
+        assert digest.hex() == rs["expected_hash"]
+
+
+class TestCrossVectorsSignVerifyRoundTrip:
+    def test_round_trip(self):
+        sign_fn = new_signer_from_hex(VECTORS["keys"]["private_key"])
+        digest = legacy_keccak256(b"round trip test")
+        sig, pub_key_bytes = sign_fn(digest)
+        pub_key = public_key_from_bytes(pub_key_bytes)
+        assert verify_signature(pub_key, digest, sig)

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -401,7 +401,7 @@ wheels = [
 
 [[package]]
 name = "t0-provider-sdk"
-version = "0.1.5"
+version = "1.1.6"
 source = { editable = "sdk" }
 dependencies = [
     { name = "coincurve" },
@@ -433,7 +433,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "t0-provider-starter"
-version = "0.1.5"
+version = "1.1.6"
 source = { editable = "starter" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Add cross-language cryptographic test vector verification to **Go**, **Python**, and **Java** SDKs using shared `cross_test/test_vectors.json` (Keccak256, key derivation, request hash, sign/verify round-trips)
- Migrate Node SDK crypto from deprecated `@noble/secp256k1` to `@noble/curves`
- Refactor Node starter CLI to use **commander** with optional **inquirer** fallback for interactive mode (supports both `provider-starter-ts <name>` and interactive prompt)
- Enable error cleanup of partial project directories on failure
- Version bumps in Go go.sum and Python uv.lock

## Test plan
- [ ] `cd node/sdk && npm test` — verify all 9 SDK tests pass
- [ ] `cd node/starter && npm run build` — verify starter builds
- [ ] `cd go && go test ./crypto/... -run Cross -v` — verify Go cross tests
- [ ] `cd python && uv run pytest sdk/tests/crypto/test_cross_vectors.py -v` — verify Python cross tests
- [ ] `cd java && ./gradlew test --tests "*CrossVector*"` — verify Java cross tests
- [ ] Test starter CLI with argument: `npx provider-starter-ts my-project`
- [ ] Test starter CLI interactive mode: `npx provider-starter-ts` (should prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)