### PR TITLE
feat: add C# SDK with cross-language integration tests

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -340,7 +340,7 @@ jobs:
         uses: NuGet/login@v1
         id: nuget-login
         with:
-          user: t0-network
+          user: stepan.romankov
 
       - name: Publish SDK to NuGet
         run: dotnet nuget push csharp/sdk/T0.ProviderSdk/bin/Release/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Summary
- Add C# SDK (`T0.ProviderSdk`) and starter CLI (`T0.ProviderStarter`) with full gRPC provider implementation
- Add cross-language crypto integration tests (Keccak256, secp256k1 signing/verification)
- Add NuGet publishing via OIDC trusted publishing to the publish workflow
- Add C# README and update root README with C# section
- Fix NuGet OIDC auth to use individual username instead of org name

## Test plan
- [ ] Verify C# SDK builds: `cd csharp && dotnet build`
- [ ] Run C# cross-language tests against `cross_test/test_vectors.json`
- [ ] Verify NuGet OIDC trusted publishing succeeds on tag push
- [ ] Confirm packages appear on nuget.org after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)