### PR TITLE
chore: remove deprecated pay-in quotes from starter templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Thumbs.db
 
 # Claude Code
 .claude/
+.claude.local.md
 
 # Go
 go/starter/template/vendor/

--- a/csharp/starter/T0.ProviderStarter/TemplateFiles.cs
+++ b/csharp/starter/T0.ProviderStarter/TemplateFiles.cs
@@ -234,27 +234,6 @@ public static class TemplateFiles
                 // Combine multiple quotes into a single request.
                 client.UpdateQuote(new UpdateQuoteRequest
                 {
-                    PayIn = // Quote at which you take local currency and settle with USDT (on-ramp)
-                    {
-                        new UpdateQuoteRequest.Types.Quote
-                        {
-                            Currency = currency,
-                            QuoteType = QuoteType.Realtime, // REALTIME is the only supported type
-                            PaymentMethod = paymentMethod,
-                            Expiration = expiration,
-                            Timestamp = timestamp,
-                            Bands = // One or more bands allowed
-                            {
-                                new UpdateQuoteRequest.Types.Quote.Types.Band
-                                {
-                                    ClientQuoteId = Guid.NewGuid().ToString(),
-                                    MaxAmount = new Decimal { Unscaled = 1000, Exponent = 0 }, // max amount in USD
-                                    // Rate is always USD/XXX (e.g. for BRL: USD/BRL)
-                                    Rate = new Decimal { Unscaled = 86, Exponent = -2 } // 0.86
-                                }
-                            }
-                        }
-                    },
                     PayOut = // Quote at which you take USDT and pay out local currency (off-ramp)
                     {
                         new UpdateQuoteRequest.Types.Quote

--- a/go/README.md
+++ b/go/README.md
@@ -143,7 +143,7 @@ _, err = networkClient.CreatePayment(ctx, connect.NewRequest(&networkproto.Creat
 - [Payout Provider Flow](examples/payout_provider_flow_test.go)
 - [Provider Service](examples/provider_service_test.go)
 - [Network Client](examples/network_client_test.go)
-- [Payment Intent Pay-in](examples/payment_intent/pay_in_flow_test.go)
+
 
 ## Development
 

--- a/go/starter/template/internal/publish_quotes.go
+++ b/go/starter/template/internal/publish_quotes.go
@@ -57,29 +57,6 @@ func PublishQuotes(ctx context.Context, networkClient paymentconnect.NetworkServ
 						},
 					},
 				},
-				PayIn: []*payment.UpdateQuoteRequest_Quote{ // The quote at which you want to take local currency and settle with USDT (on-ramp)
-					{
-						Currency:      currency,
-						QuoteType:     payment.QuoteType_QUOTE_TYPE_REALTIME, // REALTIME is only supported right now
-						PaymentMethod: paymentMethod,
-						Expiration:    expiration,
-						Timestamp:     timestamp,
-						Bands: []*payment.UpdateQuoteRequest_Quote_Band{ // one or more bands are allowed
-							{
-								ClientQuoteId: uuid.NewString(),
-								MaxAmount: &common.Decimal{
-									Unscaled: 1000, // maximum amount in USD, could be 1000, 5000, 10000 or 25000
-									Exponent: 0,
-								},
-								// note that rate is always USD/XXX, so that for BRL quote should be USD/BRL
-								Rate: &common.Decimal{ //rate 0.88
-									Unscaled: 88,
-									Exponent: -2,
-								},
-							},
-						},
-					},
-				},
 			}))
 			if err != nil {
 				log.Printf("Error updating quote: %s\n", err.Error()) // handle errors appropriately

--- a/java/starter/template/src/main/java/network/t0/provider/internal/PublishQuotes.java
+++ b/java/starter/template/src/main/java/network/t0/provider/internal/PublishQuotes.java
@@ -47,26 +47,6 @@ public class PublishQuotes {
             // Otherwise, if you send multiple requests, only the quotes from the last one will be available.
 
             networkClient.updateQuote(UpdateQuoteRequest.newBuilder()
-                    // The quote at which you want to take local currency and settle with USDT (on-ramp)
-                    .addPayIn(UpdateQuoteRequest.Quote.newBuilder()
-                            .setCurrency(currency)
-                            .setQuoteType(QuoteType.QUOTE_TYPE_REALTIME) // REALTIME is only supported right now
-                            .setPaymentMethod(paymentMethod)
-                            .setExpiration(expiration)
-                            .setTimestamp(timestamp)
-                            .addBands(UpdateQuoteRequest.Quote.Band.newBuilder()
-                                    .setClientQuoteId(UUID.randomUUID().toString())
-                                    .setMaxAmount(Decimal.newBuilder()
-                                            .setUnscaled(25000) // maximum amount in USD, could be 1000, 5000, 10000 or 25000
-                                            .setExponent(0)
-                                            .build())
-                                    // note that rate is always USD/XXX, so that for EUR quote should be USD/EUR
-                                    .setRate(Decimal.newBuilder()
-                                            .setUnscaled(863) // rate 0.863
-                                            .setExponent(-3)
-                                            .build())
-                                    .build())
-                            .build())
                     // The quote at which you want to take USDT and pay out local currency (off-ramp)
                     .addPayOut(UpdateQuoteRequest.Quote.newBuilder()
                             .setCurrency(currency)

--- a/node/starter/template/src/publish_quotes.ts
+++ b/node/starter/template/src/publish_quotes.ts
@@ -11,19 +11,6 @@ export default async function publishQuotes(networkClient: Client<typeof Network
       // So if you want to publish multiple quotes, you need to combine them into a single request.
       // Otherwise, if you send multiple requests, only the quotes from the last one will be available.
       await networkClient.updateQuote({
-        payIn: [{
-          bands: [{
-            // note that rate is always USD/XXX, os that for EUR quote should be USD/EUR
-            rate: toProtoDecimal(863, -3), // rate 0.863
-            maxAmount: toProtoDecimal(25000, 0), // maximum amount in USD, could be 1000,5000,10000 or 25000
-            clientQuoteId: randomUUID(),
-          }],
-          currency: 'EUR',
-          expiration: timestampFromDate(new Date(Date.now() + 30 * 1000)), // expiration time (30 seconds from now)
-          quoteType: QuoteType.REALTIME, // REALTIME is only one supported right now
-          paymentMethod: PaymentMethodType.SEPA,
-          timestamp: timestampFromDate(new Date()), // Current timestamp
-        }],
         payOut: [{
           bands: [{
             // note that rate is always USD/XXX, os that for EUR quote should be USD/EUR

--- a/python/starter/src/t0_provider_starter/template/src/provider/publish_quotes.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/publish_quotes.py
@@ -2,7 +2,7 @@
 
 Go equivalent: internal/publish_quotes.go → PublishQuotes()
 
-Publishes sample PayOut (off-ramp) and PayIn (on-ramp) quotes every 5 seconds.
+Publishes sample PayOut (off-ramp) quotes every 5 seconds.
 TODO: Step 1.3 Replace this with fetching quotes from your systems and publishing them.
 We recommend publishing at least once per 5 seconds, but not more than once per second.
 """
@@ -73,29 +73,6 @@ async def publish_quotes(network_client: NetworkServiceClient, shutdown_event: a
                                     # Note: rate is always USD/XXX, so for BRL quote should be USD/BRL
                                     rate=Decimal(
                                         unscaled=86,  # rate 0.86
-                                        exponent=-2,
-                                    ),
-                                ),
-                            ],
-                        ),
-                    ],
-                    pay_in=[
-                        # The quote at which you want to take local currency and settle with USDT (on-ramp)
-                        UpdateQuoteRequest.Quote(
-                            currency=currency,
-                            quote_type=QUOTE_TYPE_REALTIME,
-                            payment_method=payment_method,
-                            expiration=expiration,
-                            timestamp=timestamp,
-                            bands=[
-                                UpdateQuoteRequest.Quote.Band(
-                                    client_quote_id=str(uuid.uuid4()),
-                                    max_amount=Decimal(
-                                        unscaled=1000,
-                                        exponent=0,
-                                    ),
-                                    rate=Decimal(
-                                        unscaled=88,  # rate 0.88
                                         exponent=-2,
                                     ),
                                 ),


### PR DESCRIPTION
The pay_in field on UpdateQuoteRequest has been deprecated in the proto definition (backend sync PR #36). Remove pay-in quote usage from all language starter templates (Go, Node, Python, Java, C#) and a dead example link from the Go README.