### PR TITLE
fix: disable prehash in Node.js SDK signature sign/verify

### DIFF
--- a/cross_test/test_vectors.json
+++ b/cross_test/test_vectors.json
@@ -20,6 +20,7 @@
   "request_signing": {
     "body": "test request body",
     "timestamp_ms": 1706000000000,
-    "expected_hash": "49a567a359bf25d9652b24acc5567bc38c93139467c8fcf798f059ada585697e"
+    "expected_hash": "49a567a359bf25d9652b24acc5567bc38c93139467c8fcf798f059ada585697e",
+    "expected_signature": "dc7cede55d344fb59f10fa71b4915968a9d5c3f811faf7ddd834feb3cdce106539cd605b5a2d5fe35c21f27af92d01a68a06d6e813a613dac40e90a7a7a89181"
   }
 }

--- a/csharp/sdk/T0.ProviderSdk.Tests/Crypto/CrossTestVectors.cs
+++ b/csharp/sdk/T0.ProviderSdk.Tests/Crypto/CrossTestVectors.cs
@@ -100,4 +100,26 @@ public class CrossTestVectors
         var valid = SignatureVerifier.Verify(signer.GetPublicKey(), digest, sig64);
         Assert.True(valid);
     }
+
+    [Fact]
+    public void RequestSignature_ShouldMatchExpected()
+    {
+        var keys = Vectors.RootElement.GetProperty("keys");
+        var rs = Vectors.RootElement.GetProperty("request_signing");
+        var privateKeyHex = keys.GetProperty("private_key").GetString()!;
+        var expectedSignature = rs.GetProperty("expected_signature").GetString()!;
+
+        var body = Encoding.UTF8.GetBytes(rs.GetProperty("body").GetString()!);
+        var timestampMs = rs.GetProperty("timestamp_ms").GetInt64();
+        var tsBytes = new byte[8];
+        BinaryPrimitives.WriteUInt64LittleEndian(tsBytes, (ulong)timestampMs);
+
+        var digest = Keccak256.Hash(body, tsBytes);
+        Assert.Equal(rs.GetProperty("expected_hash").GetString()!, HexUtils.BytesToHex(digest));
+
+        var signer = Signer.FromHex(privateKeyHex);
+        var result = signer.Sign(digest);
+        // Compare first 64 bytes (r+s) against the cross-language test vector
+        Assert.Equal(expectedSignature, HexUtils.BytesToHex(result.Signature[..64]));
+    }
 }

--- a/go/crypto/cross_test.go
+++ b/go/crypto/cross_test.go
@@ -21,9 +21,10 @@ type testVectors struct {
 		Hash  string `json:"hash"`
 	} `json:"keccak256"`
 	RequestSigning struct {
-		Body         string `json:"body"`
-		TimestampMs  uint64 `json:"timestamp_ms"`
-		ExpectedHash string `json:"expected_hash"`
+		Body              string `json:"body"`
+		TimestampMs       uint64 `json:"timestamp_ms"`
+		ExpectedHash      string `json:"expected_hash"`
+		ExpectedSignature string `json:"expected_signature"`
 	} `json:"request_signing"`
 }
 
@@ -81,4 +82,23 @@ func TestCrossVectors_SignVerifyRoundTrip(t *testing.T) {
 	pubKey, err := crypto.GetPublicKeyFromBytes(pubKeyBytes)
 	require.NoError(t, err)
 	require.True(t, crypto.VerifySignature(pubKey, digest, signature))
+}
+
+func TestCrossVectors_RequestSignature(t *testing.T) {
+	v := loadVectors(t)
+	sign, err := crypto.NewSignerFromHex(v.Keys.PrivateKey)
+	require.NoError(t, err)
+
+	body := []byte(v.RequestSigning.Body)
+	tsBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(tsBytes, v.RequestSigning.TimestampMs)
+
+	combined := append(body, tsBytes...)
+	digest := crypto.LegacyKeccak256(combined)
+	require.Equal(t, v.RequestSigning.ExpectedHash, hex.EncodeToString(digest))
+
+	signature, _, err := sign(digest)
+	require.NoError(t, err)
+	// Compare first 64 bytes (r+s) against the cross-language test vector
+	require.Equal(t, v.RequestSigning.ExpectedSignature, hex.EncodeToString(signature[:64]))
 }

--- a/java/sdk/src/test/java/network/t0/sdk/crypto/CrossVectorTest.java
+++ b/java/sdk/src/test/java/network/t0/sdk/crypto/CrossVectorTest.java
@@ -85,4 +85,30 @@ class CrossVectorTest {
                 signer.getPublicKey(), digest, result.getSignature());
         assertThat(valid).isTrue();
     }
+
+    @Test
+    void requestSignature_shouldMatchExpected() {
+        JsonObject keys = vectors.getAsJsonObject("keys");
+        JsonObject rs = vectors.getAsJsonObject("request_signing");
+        String privateKeyHex = keys.get("private_key").getAsString();
+        String expectedSignature = rs.get("expected_signature").getAsString();
+
+        byte[] body = rs.get("body").getAsString().getBytes();
+        long timestampMs = rs.get("timestamp_ms").getAsLong();
+        byte[] tsBytes = ByteBuffer.allocate(8)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putLong(timestampMs)
+                .array();
+
+        byte[] digest = Keccak256.hash(body, tsBytes);
+        assertThat(HexUtils.bytesToHex(digest))
+                .isEqualTo(rs.get("expected_hash").getAsString());
+
+        Signer signer = Signer.fromHex(privateKeyHex);
+        SignResult result = signer.sign(digest);
+        // Compare first 64 bytes (r+s) against the cross-language test vector
+        byte[] sig64 = new byte[64];
+        System.arraycopy(result.getSignature(), 0, sig64, 0, 64);
+        assertThat(HexUtils.bytesToHex(sig64)).isEqualTo(expectedSignature);
+    }
 }

--- a/node/sdk/src/client/signer.ts
+++ b/node/sdk/src/client/signer.ts
@@ -12,7 +12,7 @@ export const CreateSigner = (privateKey: string | Buffer)=> {
         }
 
         // Sign the hash
-        const signature = secp256k1.sign(data, privateKey);
+        const signature = secp256k1.sign(data, privateKey, {prehash: false});
 
         return {
             signature: Buffer.from(signature),

--- a/node/sdk/src/service/service.ts
+++ b/node/sdk/src/service/service.ts
@@ -42,7 +42,7 @@ const createSignatureVerification: (networkPublicKey: Buffer) => Interceptor = (
     .digest();
   let signatureValid = false;
   try {
-    signatureValid = secp256k1.verify(signature, hash, publicKey);
+    signatureValid = secp256k1.verify(signature, hash, publicKey, {prehash: false});
   } catch (e) {
     throw new ConnectError(`${NetworkHeaders.Signature} has invalid signature or public key format: ${e}` , Code.Unauthenticated);
   }

--- a/node/sdk/test/crypto.test.ts
+++ b/node/sdk/test/crypto.test.ts
@@ -33,12 +33,11 @@ describe('CreateSigner', () => {
     nodeAssert.equal(sig.publicKey.toString('hex'), vectors.keys.public_key);
   });
 
-  it('produces a 65-byte signature', async () => {
+  it('produces a 64-byte compact signature', async () => {
     const signer = CreateSigner(vectors.keys.private_key);
     const hash = Buffer.from(keccak_256(Buffer.from('test', 'utf-8')));
     const sig = await signer(hash);
-    // secp256k1 compact signature is 64 bytes; with recovery byte it's 65
-    nodeAssert.ok(sig.signature.length === 64 || sig.signature.length === 65);
+    nodeAssert.equal(sig.signature.length, 64);
   });
 
   it('rejects non-32-byte input', async () => {
@@ -54,7 +53,7 @@ describe('CreateSigner', () => {
   });
 });
 
-describe('Request signing hash', () => {
+describe('Request signing', () => {
   it('computes correct hash for body + timestamp', () => {
     const { body, timestamp_ms, expected_hash } = vectors.request_signing;
 
@@ -67,5 +66,25 @@ describe('Request signing hash', () => {
     const result = Buffer.from(hash.digest()).toString('hex');
 
     nodeAssert.equal(result, expected_hash);
+  });
+
+  it('produces signature matching cross-language test vector', async () => {
+    const { body, timestamp_ms, expected_hash, expected_signature } = vectors.request_signing;
+
+    const signer = CreateSigner(vectors.keys.private_key);
+
+    const tsBuf = Buffer.alloc(8);
+    tsBuf.writeBigUInt64LE(BigInt(timestamp_ms));
+
+    const digest = Buffer.from(
+      keccak_256.create()
+        .update(Buffer.from(body, 'utf-8'))
+        .update(tsBuf)
+        .digest()
+    );
+    nodeAssert.equal(digest.toString('hex'), expected_hash);
+
+    const sig = await signer(digest);
+    nodeAssert.equal(sig.signature.subarray(0, 64).toString('hex'), expected_signature);
   });
 });

--- a/python/sdk/tests/crypto/test_cross_vectors.py
+++ b/python/sdk/tests/crypto/test_cross_vectors.py
@@ -51,3 +51,17 @@ class TestCrossVectorsSignVerifyRoundTrip:
         sig, pub_key_bytes = sign_fn(digest)
         pub_key = public_key_from_bytes(pub_key_bytes)
         assert verify_signature(pub_key, digest, sig)
+
+
+class TestCrossVectorsRequestSignature:
+    def test_signature_matches_vector(self):
+        rs = VECTORS["request_signing"]
+        body = rs["body"].encode()
+        ts_bytes = struct.pack("<Q", rs["timestamp_ms"])
+        digest = legacy_keccak256(body + ts_bytes)
+        assert digest.hex() == rs["expected_hash"]
+
+        sign_fn = new_signer_from_hex(VECTORS["keys"]["private_key"])
+        sig, _ = sign_fn(digest)
+        # Compare first 64 bytes (r+s) against the cross-language test vector
+        assert sig[:64].hex() == rs["expected_signature"]


### PR DESCRIPTION
## Summary
- `@noble/curves` v2.x changed `prehash` default from `false` to `true`, causing `secp256k1.sign()` to apply SHA-256 on top of the already-Keccak256'd digest
- This produced signatures the Go backend rejects — observed as "signature verification failed" for provider ID 23 on `network-prod`
- Passes `{prehash: false}` to both `sign()` in `signer.ts` and `verify()` in `service.ts`
- Adds `expected_signature` to cross-language test vectors and a test that verifies Node.js signatures match the Go-generated reference

## Test plan
- [x] All existing Node.js SDK tests pass
- [x] New cross-language signature test verifies output matches Go's go-ethereum reference
- [ ] Verify provider ID 23 signature errors stop after SDK release
- [ ] Check Python/Java/C# SDKs for the same `prehash` default issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)