### PR TITLE
chore(deps): consolidate all dependency updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
           distribution: "temurin"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -74,7 +74,7 @@ jobs:
           distribution: "temurin"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: true
 
@@ -283,7 +283,7 @@ jobs:
           distribution: "temurin"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Get version from tag
         id: version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
           distribution: "temurin"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: true
 

--- a/go/starter/go.mod
+++ b/go/starter/go.mod
@@ -3,7 +3,7 @@ module github.com/t-0-network/provider-sdk/go/starter
 go 1.25.0
 
 require (
-	github.com/ethereum/go-ethereum v1.17.1
+	github.com/ethereum/go-ethereum v1.17.2
 	github.com/joho/godotenv v1.5.1
 	golang.org/x/mod v0.34.0
 )

--- a/go/starter/go.sum
+++ b/go/starter/go.sum
@@ -4,8 +4,8 @@ github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 h1:5RVFMOWjMyRy8cARdy79nAmgYw3hK/4HUq48LQ6Wwqo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
-github.com/ethereum/go-ethereum v1.17.1 h1:IjlQDjgxg2uL+GzPRkygGULPMLzcYWncEI7wbaizvho=
-github.com/ethereum/go-ethereum v1.17.1/go.mod h1:7UWOVHL7K3b8RfVRea022btnzLCaanwHtBuH1jUCH/I=
+github.com/ethereum/go-ethereum v1.17.2 h1:ag6geu0kn8Hv5FLKTpH+Hm2DHD+iuFtuqKxEuwUsDOI=
+github.com/ethereum/go-ethereum v1.17.2/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
 github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/java/cli/build.gradle.kts
+++ b/java/cli/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     application
-    id("com.gradleup.shadow") version "9.4.0"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 val picocliVersion = "4.7.7"

--- a/java/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/java/gradlew
+++ b/java/gradlew
@@ -57,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/b631911858264c0b6e4d6603d677ff5218766cee/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/2d6327017519d23b96af35865dc997fcb544fb40/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/java/sdk/build.gradle.kts
+++ b/java/sdk/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
     // Protobuf
     api("com.google.protobuf:protobuf-java:$protobufVersion")
-    api("build.buf:protovalidate:1.1.1")
+    api("build.buf:protovalidate:1.1.2")
 
     // BouncyCastle for crypto (secp256k1, Keccak-256)
     implementation("org.bouncycastle:bcprov-jdk18on:$bouncyCastleVersion")

--- a/java/sdk/build.gradle.kts
+++ b/java/sdk/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 val grpcVersion = "1.80.0"
-val protobufVersion = "4.34.0"
+val protobufVersion = "4.34.1"
 val bouncyCastleVersion = "1.83"
 
 dependencies {

--- a/node/sdk/package-lock.json
+++ b/node/sdk/package-lock.json
@@ -20,7 +20,7 @@
         "@types/node": "^25.4.0",
         "dotenv": "^17.3.1",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.2"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/node/sdk/package.json
+++ b/node/sdk/package.json
@@ -40,7 +40,7 @@
     "@types/node": "^25.4.0",
     "dotenv": "^17.3.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   },
   "scripts": {
     "buf:generate": "buf generate",

--- a/node/sdk/tsconfig.cjs.json
+++ b/node/sdk/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "outDir": "./lib/cjs",
     "declaration": true,
     "declarationMap": false

--- a/node/sdk/tsconfig.json
+++ b/node/sdk/tsconfig.json
@@ -12,11 +12,11 @@
     "isolatedModules": false,
     "incremental": true,
     "rootDir": "./src",
-    "baseUrl": "./src",
     "outDir": "./lib",
     "declaration": true,
     "declarationMap": false,
-    "allowJs": true
+    "allowJs": true,
+    "types": ["node"]
   },
   "include": [
     "src/**/*.ts"

--- a/node/starter/package-lock.json
+++ b/node/starter/package-lock.json
@@ -21,7 +21,7 @@
         "@types/fs-extra": "^11.0.4",
         "@types/inquirer": "^9.0.9",
         "@types/node": "^25.4.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.2"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -590,9 +590,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/node/starter/package.json
+++ b/node/starter/package.json
@@ -39,6 +39,6 @@
     "@types/fs-extra": "^11.0.4",
     "@types/inquirer": "^9.0.9",
     "@types/node": "^25.4.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/node/starter/template/tsconfig.json
+++ b/node/starter/template/tsconfig.json
@@ -13,7 +13,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/node/starter/tsconfig.json
+++ b/node/starter/tsconfig.json
@@ -13,7 +13,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "types": ["node"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary

Consolidates 8 Dependabot PRs into a single update, with TypeScript 6.0 compatibility fixes.

### Dependency Updates

| Language | Package | From | To | Type |
|----------|---------|------|----|------|
| Go | `github.com/ethereum/go-ethereum` | 1.17.1 | 1.17.2 | patch |
| Node | `typescript` (SDK + Starter) | 5.9.3 | 6.0.2 | **major** |
| Java | `build.buf:protovalidate` | 1.1.1 | 1.1.2 | patch |
| Java | `com.gradleup.shadow` | 9.4.0 | 9.4.1 | patch |
| Java | `com.google.protobuf:protobuf-java` | 4.34.0 | 4.34.1 | patch |
| Java | Gradle wrapper | 9.4.0 | 9.4.1 | patch |
| CI | `gradle/actions` | 5 | 6 | **major** |

### Breaking Change Analysis

**TypeScript 5.9.3 → 6.0.2 (major):**
- `moduleResolution: "node"` deprecated (removed in TS 7.0) → migrated to `"bundler"` for CJS configs
- `baseUrl` deprecated → removed (was unused, no non-relative imports exist)
- Default `types` changed to `[]` → added explicit `"types": ["node"]` to SDK base tsconfig
- `esModuleInterop` now always enabled → no impact (we already set it to `true`)
- `target: "ES2020"` still supported → no change needed

**gradle/actions 5 → 6 (major):**
- Only breaking change: removal of experimental Configuration Cache support (we don't use it)
- Caching license changed but remains free for public repos
- `cache-read-only` parameter still works

**All other updates are patch versions with no breaking changes.**

### Closes

Closes #48, closes #47, closes #46, closes #42, closes #41, closes #40, closes #39, closes #38

## Test plan

- [x] Go tests pass (`go test ./...`)
- [x] Node SDK builds and all 10 tests pass (`npm run build && npm test`)
- [x] Node Starter builds cleanly (`npm run build`)
- [x] Java full build passes including SDK tests (`./gradlew build`)
- [x] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)