### PR TITLE
feat: add payment intent flow examples to all SDK starters

### DIFF
--- a/go/starter/README.md
+++ b/go/starter/README.md
@@ -15,20 +15,24 @@ This creates a ready-to-run project with a secp256k1 keypair, environment config
 ```
 my-provider/
 ├── cmd/
-│   └── main.go              # Entry point
+│   └── main.go                                # Entry point
 ├── internal/
 │   ├── handler/
-│   │   ├── provider.go      # Provider service implementation
-│   │   └── payment.go       # Payment handler implementation
-│   ├── get_quote.go         # Quote retrieval logic
-│   ├── publish_quotes.go    # Quote publishing logic
-│   └── service.go           # Service utilities
-├── .env                     # Environment variables (with generated keys)
-├── .env.example             # Example environment file
-├── .gitignore               # Git ignore rules
-├── Dockerfile               # Docker configuration
-├── go.mod                   # Go module definition
-└── go.sum                   # Go dependencies checksums
+│   │   ├── payment.go                         # Phase 2: ProviderService handler
+│   │   ├── payment_intent_pay_in.go           # Phase 3A: PayInProviderService handler
+│   │   └── payment_intent_beneficiary.go      # Phase 3B: BeneficiaryService handler
+│   ├── get_quote.go                           # Phase 1: quote retrieval
+│   ├── publish_quotes.go                      # Phase 1: payout quote publishing
+│   ├── publish_payment_intent_quotes.go       # Phase 3A: pay-in quote publishing
+│   ├── get_payment_intent_quote.go            # Phase 3B: indicative quote retrieval
+│   ├── create_payment_intent.go               # Phase 3B: create a payment intent
+│   └── confirm_funds_received.go              # Phase 3A: confirm funds received
+├── .env                                       # Environment variables (with generated keys)
+├── .env.example                               # Example environment file
+├── .gitignore                                 # Git ignore rules
+├── Dockerfile                                 # Docker configuration
+├── go.mod                                     # Go module definition
+└── go.sum                                     # Go dependencies checksums
 ```
 
 ## Key Files to Modify
@@ -63,6 +67,26 @@ my-provider/
 2. Deploy your service and share the base URL with the T-0 team.
 3. Implement `PayOut` handler in `internal/handler/payment.go`.
 4. Coordinate with the T-0 team to test end-to-end payment flows.
+
+### Phase 3: Payment Intent Flow
+
+The payment intent flow is independent of Phase 2. It is an asynchronous pay-in flow where an end-user pays a pay-in provider in fiat (bank transfer, mobile money, etc.) and a beneficiary provider receives settlement on the crypto side. Quotes are indicative until funds are received, settlement happens periodically, and a confirmation code links the end-user's payment back to a specific payment intent.
+
+Implement **one** of the two sub-phases below depending on your role. If you participate on both sides, implement both.
+
+**Phase 3A -- Pay-In Provider role** (skip if you're a beneficiary):
+
+1. **Step 3A.1** Replace the sample pay-in quote publishing in `internal/publish_payment_intent_quotes.go` with your own.
+2. **Step 3A.2** Implement `GetPaymentDetails` in `internal/handler/payment_intent_pay_in.go` -- return bank account / mobile money details plus a payment reference the end-user will include in their transfer.
+3. **Step 3A.3** When you detect the end-user's fiat payment, call `ConfirmFundsReceived` (see `internal/confirm_funds_received.go`).
+
+**Phase 3B -- Beneficiary Provider role** (skip if you're pay-in):
+
+1. **Step 3B.1** Verify indicative quotes are returned (`internal/get_payment_intent_quote.go`).
+2. **Step 3B.2** Create payment intents for your end-users via `CreatePaymentIntent` (see `internal/create_payment_intent.go`).
+3. **Step 3B.3** Implement `PaymentIntentUpdate` in `internal/handler/payment_intent_beneficiary.go` to receive notifications when funds are received.
+
+If you only play one role, delete the files for the other role and remove the corresponding handler registration in `cmd/main.go`.
 
 ## Available Commands
 

--- a/go/starter/template/cmd/main.go
+++ b/go/starter/template/cmd/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment/paymentconnect"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent/payment_intentconnect"
 	"github.com/t-0-network/provider-sdk/go/network"
 	"github.com/t-0-network/provider-sdk/go/provider"
 	"github.com/t-0-network/provider-sdk/go/starter/template/internal"
@@ -26,8 +27,9 @@ func main() {
 	config := loadConfig()
 
 	networkClient := initNetworkClient(config)
+	paymentIntentClient := initPaymentIntentClient(config)
 
-	shutdownFunc := startProviderServer(config, networkClient)
+	shutdownFunc := startProviderServer(config, networkClient, paymentIntentClient)
 	defer shutdownFunc()
 
 	// ✅ Step 1.1 is done. You successfully initialised starter template
@@ -43,6 +45,22 @@ func main() {
 
 	// TODO: Step 1.4 Verify that quotes for target currency are successfully received
 	go internal.GetQuote(ctx, networkClient)
+
+	// ──────────────────────────────────────────────────────────────
+	// Payment Intent Flow — Phase 3
+	//
+	// Implement the role that applies to you. See the README for details.
+	// ──────────────────────────────────────────────────────────────
+
+	// Phase 3A — Pay-In Provider role. Comment out if you are only a beneficiary.
+	// TODO: Step 3A.1 Replace with your own pay-in quote publishing logic
+	go internal.PublishPaymentIntentQuotes(ctx, paymentIntentClient)
+
+	// Phase 3B — Beneficiary Provider role. Comment out if you are only a pay-in provider.
+	// TODO: Step 3B.1 Check that indicative quotes are being returned
+	go internal.GetPaymentIntentQuote(ctx, paymentIntentClient)
+	// TODO: Step 3B.2 Create a payment intent for a real end-user when they want to pay
+	// internal.CreatePaymentIntent(ctx, paymentIntentClient)
 
 	waitForShutdownSignal(cancel, shutdownFunc)
 
@@ -76,11 +94,33 @@ func initNetworkClient(config Config) paymentconnect.NetworkServiceClient {
 	return networkClient
 }
 
-func startProviderServer(config Config, networkClient paymentconnect.NetworkServiceClient) func() {
+func initPaymentIntentClient(config Config) payment_intentconnect.PaymentIntentServiceClient {
+	paymentIntentClient, err := network.NewServiceClient(
+		config.ProviderPrivateKey,
+		payment_intentconnect.NewPaymentIntentServiceClient,
+		network.WithBaseURL(config.TZeroEndpoint),
+	)
+	if err != nil {
+		log.Fatalf("Failed to create payment intent service client: %v", err)
+	}
+	return paymentIntentClient
+}
+
+func startProviderServer(
+	config Config,
+	networkClient paymentconnect.NetworkServiceClient,
+	paymentIntentClient payment_intentconnect.PaymentIntentServiceClient,
+) func() {
 	providerServiceHandler, err := provider.NewHttpHandler(
 		config.NetworkPublicKey,
 		provider.Handler(paymentconnect.NewProviderServiceHandler,
 			paymentconnect.ProviderServiceHandler(handler.NewProviderServiceImplementation(networkClient))),
+		// Phase 3A — Pay-In Provider role. Remove if you are only a beneficiary.
+		provider.Handler(payment_intentconnect.NewPayInProviderServiceHandler,
+			payment_intentconnect.PayInProviderServiceHandler(handler.NewPayInProviderServiceImplementation(paymentIntentClient))),
+		// Phase 3B — Beneficiary Provider role. Remove if you are only a pay-in provider.
+		provider.Handler(payment_intentconnect.NewBeneficiaryServiceHandler,
+			payment_intentconnect.BeneficiaryServiceHandler(handler.NewBeneficiaryServiceImplementation())),
 	)
 	if err != nil {
 		log.Fatalf("Failed to create provider service handler: %v", err)

--- a/go/starter/template/internal/confirm_funds_received.go
+++ b/go/starter/template/internal/confirm_funds_received.go
@@ -1,0 +1,46 @@
+package internal
+
+import (
+	"context"
+	"log"
+
+	"connectrpc.com/connect"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/common"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent/payment_intentconnect"
+)
+
+// ConfirmFundsReceived notifies the t-0 Network that an end-user has paid.
+//
+// Pay-In Provider role — Step 3A.3.
+// Call this after you have matched an incoming fiat payment to a payment intent
+// (using the payment reference you returned from GetPaymentDetails). Settlement
+// with the beneficiary provider will proceed once this confirmation is accepted.
+func ConfirmFundsReceived(
+	ctx context.Context,
+	paymentIntentClient payment_intentconnect.PaymentIntentServiceClient,
+	paymentIntentId uint64,
+	confirmationCode string,
+	transactionReference string,
+) {
+	response, err := paymentIntentClient.ConfirmFundsReceived(ctx, connect.NewRequest(&payment_intent.ConfirmFundsReceivedRequest{
+		PaymentIntentId:      paymentIntentId,
+		ConfirmationCode:     confirmationCode,
+		PaymentMethod:        common.PaymentMethodType_PAYMENT_METHOD_TYPE_SEPA,
+		TransactionReference: transactionReference,
+		// optional: if your provider has multiple legal entities, set OriginatorProviderLegalEntityId
+	}))
+	if err != nil {
+		log.Printf("Error confirming funds received: %s\n", err.Error())
+		return
+	}
+
+	switch r := response.Msg.Result.(type) {
+	case *payment_intent.ConfirmFundsReceivedResponse_Accept_:
+		log.Printf("Funds accepted for payment intent %d\n", paymentIntentId)
+	case *payment_intent.ConfirmFundsReceivedResponse_Reject_:
+		log.Printf("Funds rejected for payment intent %d: %s\n", paymentIntentId, r.Reject.GetReason())
+	default:
+		log.Println("Unknown response type")
+	}
+}

--- a/go/starter/template/internal/create_payment_intent.go
+++ b/go/starter/template/internal/create_payment_intent.go
@@ -1,0 +1,49 @@
+package internal
+
+import (
+	"context"
+	"log"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/t-0-network/provider-sdk/go/api/ivms101/v1/ivms"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/common"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent/payment_intentconnect"
+)
+
+// CreatePaymentIntent initiates a new payment intent with the t-0 Network.
+//
+// Beneficiary Provider role — Step 3B.2.
+// Store the returned PaymentIntentId to correlate with the PaymentIntentUpdate
+// notification you'll receive on your BeneficiaryService handler once the end-user
+// completes the pay-in.
+func CreatePaymentIntent(ctx context.Context, paymentIntentClient payment_intentconnect.PaymentIntentServiceClient) {
+	response, err := paymentIntentClient.CreatePaymentIntent(ctx, connect.NewRequest(&payment_intent.CreatePaymentIntentRequest{
+		ExternalReference: uuid.NewString(), // idempotency key — reuse to retry without duplicating the intent
+		Currency:          "EUR",
+		Amount:            &common.Decimal{Unscaled: 500, Exponent: 0}, // end-user pays 500 EUR
+		TravelRuleData: &payment_intent.CreatePaymentIntentRequest_TravelRuleData{
+			// TODO: populate real IVMS101 beneficiary information for your end-user.
+			Beneficiary: []*ivms.Person{{}},
+		},
+	}))
+	if err != nil {
+		log.Printf("Error creating payment intent: %s\n", err.Error())
+		return
+	}
+
+	switch r := response.Msg.Result.(type) {
+	case *payment_intent.CreatePaymentIntentResponse_Success_:
+		log.Printf("Created payment intent id=%d with %d pay-in option(s)\n",
+			r.Success.GetPaymentIntentId(),
+			len(r.Success.GetPayInDetails()),
+		)
+		// TODO: persist (payment_intent_id, external_reference) and present the
+		// PayInDetails options to your end-user.
+	case *payment_intent.CreatePaymentIntentResponse_Failure_:
+		log.Printf("Failed to create payment intent: %s\n", r.Failure.GetReason())
+	default:
+		log.Println("Unknown response type")
+	}
+}

--- a/go/starter/template/internal/get_payment_intent_quote.go
+++ b/go/starter/template/internal/get_payment_intent_quote.go
@@ -1,0 +1,39 @@
+package internal
+
+import (
+	"context"
+	"log"
+
+	"connectrpc.com/connect"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/common"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent/payment_intentconnect"
+)
+
+// GetPaymentIntentQuote fetches indicative quotes for a pay-in currency/amount.
+//
+// Beneficiary Provider role — Step 3B.1.
+// Use this to check available rates before creating a payment intent. The actual
+// settlement rate is determined when the pay-in provider confirms funds received.
+func GetPaymentIntentQuote(ctx context.Context, paymentIntentClient payment_intentconnect.PaymentIntentServiceClient) {
+	quote, err := paymentIntentClient.GetQuote(ctx, connect.NewRequest(&payment_intent.GetQuoteRequest{
+		Currency: "EUR",
+		Amount:   &common.Decimal{Unscaled: 500, Exponent: 0}, // end-user pays 500 EUR
+	}))
+	if err != nil {
+		log.Printf("Error getting payment intent quote: %s\n", err.Error())
+		return
+	}
+
+	switch quote.Msg.Result.(type) {
+	case *payment_intent.GetQuoteResponse_Success_:
+		log.Printf("Got %d best pay-in quotes and %d total quotes\n",
+			len(quote.Msg.GetSuccess().GetBestQuotes()),
+			len(quote.Msg.GetSuccess().GetAllQuotes()),
+		)
+	case *payment_intent.GetQuoteResponse_QuoteNotFound_:
+		log.Println("No pay-in quotes available for this currency/amount")
+	default:
+		log.Println("Unknown response type")
+	}
+}

--- a/go/starter/template/internal/handler/payment_intent_beneficiary.go
+++ b/go/starter/template/internal/handler/payment_intent_beneficiary.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"context"
+	"log"
+
+	"connectrpc.com/connect"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent/payment_intentconnect"
+)
+
+/*
+  Payment Intent Flow — Beneficiary Provider role.
+
+  Implement this handler if you are a beneficiary provider (you receive settlement
+  for the crypto side). Please refer to docs and proto definition comments to
+  understand the full flow.
+*/
+
+type BeneficiaryServiceImplementation struct{}
+
+func NewBeneficiaryServiceImplementation() *BeneficiaryServiceImplementation {
+	return &BeneficiaryServiceImplementation{}
+}
+
+var _ payment_intentconnect.BeneficiaryServiceHandler = (*BeneficiaryServiceImplementation)(nil)
+
+// TODO: Step 3B.3 Implement how you handle notifications about your payment intents.
+//
+// The network calls this endpoint when the status of one of your payment intents
+// changes (e.g. funds received from the end-user). Correlate req.PaymentIntentId
+// with the id you stored after calling CreatePaymentIntent and update your
+// internal state accordingly.
+func (s *BeneficiaryServiceImplementation) PaymentIntentUpdate(
+	ctx context.Context, req *connect.Request[payment_intent.PaymentIntentUpdateRequest],
+) (*connect.Response[payment_intent.PaymentIntentUpdateResponse], error) {
+	switch u := req.Msg.Update.(type) {
+	case *payment_intent.PaymentIntentUpdateRequest_FundsReceived_:
+		log.Printf("payment intent %d: funds received, settlement_amount=%v payment_method=%s transaction_reference=%s\n",
+			req.Msg.PaymentIntentId,
+			u.FundsReceived.GetSettlementAmount(),
+			u.FundsReceived.GetPaymentMethod(),
+			u.FundsReceived.GetTransactionReference(),
+		)
+	default:
+		log.Printf("payment intent %d: unknown update variant\n", req.Msg.PaymentIntentId)
+	}
+	return connect.NewResponse(&payment_intent.PaymentIntentUpdateResponse{}), nil
+}

--- a/go/starter/template/internal/handler/payment_intent_pay_in.go
+++ b/go/starter/template/internal/handler/payment_intent_pay_in.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent/payment_intentconnect"
+)
+
+/*
+  Payment Intent Flow — Pay-In Provider role.
+
+  Implement this handler if you are a pay-in provider (you receive fiat from end-users).
+  Please refer to docs and proto definition comments to understand the full flow.
+*/
+
+type PayInProviderServiceImplementation struct {
+	paymentIntentClient payment_intentconnect.PaymentIntentServiceClient
+}
+
+func NewPayInProviderServiceImplementation(
+	paymentIntentClient payment_intentconnect.PaymentIntentServiceClient,
+) *PayInProviderServiceImplementation {
+	return &PayInProviderServiceImplementation{
+		paymentIntentClient: paymentIntentClient,
+	}
+}
+
+var _ payment_intentconnect.PayInProviderServiceHandler = (*PayInProviderServiceImplementation)(nil)
+
+// TODO: Step 3A.2 Implement how you return payment details for the end-user.
+//
+// The network calls this endpoint during CreatePaymentIntent processing. Return
+// payment details (bank account, mobile money number, etc.) for each requested
+// payment method, including a unique payment reference that will let you match
+// the incoming fiat payment back to this payment intent.
+//
+// Store (payment_intent_id, confirmation_code) so you can validate it later
+// in ConfirmFundsReceived.
+func (s *PayInProviderServiceImplementation) GetPaymentDetails(
+	ctx context.Context, req *connect.Request[payment_intent.GetPaymentDetailsRequest],
+) (*connect.Response[payment_intent.GetPaymentDetailsResponse], error) {
+	// Example: return an empty Details response — replace with your real payment instructions.
+	return connect.NewResponse(&payment_intent.GetPaymentDetailsResponse{
+		Result: &payment_intent.GetPaymentDetailsResponse_Details_{
+			Details: &payment_intent.GetPaymentDetailsResponse_Details{
+				PaymentDetails: nil, // TODO: populate one PaymentDetails per requested payment_method
+			},
+		},
+	}), nil
+}

--- a/go/starter/template/internal/publish_payment_intent_quotes.go
+++ b/go/starter/template/internal/publish_payment_intent_quotes.go
@@ -1,0 +1,70 @@
+package internal
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/common"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment_intent/payment_intentconnect"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// PublishPaymentIntentQuotes publishes pay-in quotes into the t-0 Network.
+//
+// Pay-In Provider role — Step 3A.1.
+// These quotes tell the network what exchange rates you're willing to accept
+// when an end-user pays via one of your supported payment methods.
+func PublishPaymentIntentQuotes(ctx context.Context, paymentIntentClient payment_intentconnect.PaymentIntentServiceClient) {
+	// TODO: Step 3A.1 replace this with fetching pay-in quotes from your systems and publishing them.
+	// We recommend publishing at least once per 5 seconds, but not more than once per second.
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			currency := "EUR"
+			paymentMethod := common.PaymentMethodType_PAYMENT_METHOD_TYPE_SEPA
+			expiration := timestamppb.New(time.Now().Add(30 * time.Second)) // expiration time - 30 seconds from now
+			timestamp := timestamppb.New(time.Now())                        // current timestamp
+
+			// NOTE: Every UpdateQuote request discards all previous payment intent quotes
+			// that were published before. Combine multiple quotes into a single request.
+			_, err := paymentIntentClient.UpdateQuote(ctx, connect.NewRequest(&payment_intent.UpdateQuoteRequest{
+				PaymentIntentQuotes: []*payment_intent.UpdateQuoteRequest_Quote{
+					{
+						Currency:      currency,
+						PaymentMethod: paymentMethod,
+						Expiration:    expiration,
+						Timestamp:     timestamp,
+						Bands: []*payment_intent.UpdateQuoteRequest_Quote_Band{
+							{
+								ClientQuoteId: uuid.NewString(),
+								MaxAmount: &common.Decimal{
+									Unscaled: 1000, // max amount in USD the band applies to
+									Exponent: 0,
+								},
+								// rate is always USD/XXX, so for EUR quote should be USD/EUR
+								Rate: &common.Decimal{ // rate 0.92
+									Unscaled: 92,
+									Exponent: -2,
+								},
+							},
+						},
+					},
+				},
+			}))
+			if err != nil {
+				log.Printf("Error updating payment intent quote: %s\n", err.Error())
+				return
+			}
+		}
+	}
+}

--- a/java/starter/template/README.md
+++ b/java/starter/template/README.md
@@ -43,18 +43,44 @@ Follow these steps in order to complete your integration:
 4. **Step 2.4** Implement `payOut` in `PaymentHandler.java`
 5. **Step 2.5** Ask T-0 team to submit a test payment
 
+### Step 3: Payment Intent Flow
+
+The payment intent flow is independent of Step 2. It is an asynchronous pay-in flow where an end-user pays a pay-in provider in fiat (bank transfer, mobile money, etc.) and a beneficiary provider receives settlement on the crypto side. Quotes are indicative until funds are received, settlement happens periodically, and a confirmation code links the end-user's payment back to a specific payment intent.
+
+Implement **one** of the two sub-phases below depending on your role. If you participate on both sides, implement both.
+
+**Phase 3A -- Pay-In Provider role** (skip if you're a beneficiary):
+
+1. **Step 3A.1** Replace the sample pay-in quote publishing in `internal/PublishPaymentIntentQuotes.java` with your own.
+2. **Step 3A.2** Implement `getPaymentDetails` in `handler/PaymentIntentPayInHandler.java` -- return bank account / mobile money details plus a payment reference the end-user will include in their transfer.
+3. **Step 3A.3** When you detect the end-user's fiat payment, call `confirmFundsReceived` (see `internal/ConfirmFundsReceived.java`).
+
+**Phase 3B -- Beneficiary Provider role** (skip if you're pay-in):
+
+1. **Step 3B.1** Verify indicative quotes are returned (`internal/GetPaymentIntentQuote.java`).
+2. **Step 3B.2** Create payment intents for your end-users via `CreatePaymentIntent.create(...)` (see `internal/CreatePaymentIntent.java`).
+3. **Step 3B.3** Implement `paymentIntentUpdate` in `handler/PaymentIntentBeneficiaryHandler.java` to receive notifications when funds are received.
+
+If you only play one role, delete the files for the other role and remove the corresponding `.withService(...)` call in `Main.java`.
+
 ## Project Structure
 
 ```
 src/main/java/network/t0/provider/
-├── Main.java                    # Entry point with integration steps
-├── Config.java                  # Configuration record
+├── Main.java                                # Entry point with integration steps
+├── Config.java                              # Configuration record
 ├── handler/
-│   └── PaymentHandler.java      # ProviderService implementation
+│   ├── PaymentHandler.java                  # Phase 2: ProviderService handler
+│   ├── PaymentIntentPayInHandler.java       # Phase 3A: PayInProviderService handler
+│   └── PaymentIntentBeneficiaryHandler.java # Phase 3B: BeneficiaryService handler
 └── internal/
-    ├── PublishQuotes.java       # Quote publishing logic
-    ├── GetQuote.java            # Quote fetching for testing
-    └── SubmitPayment.java       # Payment submission for testing
+    ├── PublishQuotes.java                   # Phase 1: payout quote publishing
+    ├── GetQuote.java                        # Phase 1: quote retrieval
+    ├── SubmitPayment.java                   # Phase 2: payment submission
+    ├── PublishPaymentIntentQuotes.java      # Phase 3A: pay-in quote publishing
+    ├── GetPaymentIntentQuote.java           # Phase 3B: indicative quote retrieval
+    ├── CreatePaymentIntent.java             # Phase 3B: create a payment intent
+    └── ConfirmFundsReceived.java            # Phase 3A: confirm funds received
 ```
 
 ## Key Classes

--- a/java/starter/template/src/main/java/network/t0/provider/Main.java
+++ b/java/starter/template/src/main/java/network/t0/provider/Main.java
@@ -2,11 +2,16 @@ package network.t0.provider;
 
 import io.github.cdimascio.dotenv.Dotenv;
 import network.t0.provider.handler.PaymentHandler;
+import network.t0.provider.handler.PaymentIntentBeneficiaryHandler;
+import network.t0.provider.handler.PaymentIntentPayInHandler;
+import network.t0.provider.internal.GetPaymentIntentQuote;
 import network.t0.provider.internal.GetQuote;
+import network.t0.provider.internal.PublishPaymentIntentQuotes;
 import network.t0.provider.internal.PublishQuotes;
 import network.t0.sdk.crypto.Signer;
 import network.t0.sdk.network.BlockingNetworkClient;
 import network.t0.sdk.proto.tzero.v1.payment.NetworkServiceGrpc;
+import network.t0.sdk.proto.tzero.v1.payment_intent.PaymentIntentServiceGrpc;
 import network.t0.sdk.provider.ProviderServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +54,10 @@ public class Main {
         var networkClient = BlockingNetworkClient.create(
                 config.tzeroEndpoint(), signer, NetworkServiceGrpc::newBlockingStub);
 
-        ProviderServer server = startProviderServer(config, networkClient);
+        var paymentIntentClient = BlockingNetworkClient.create(
+                config.tzeroEndpoint(), signer, PaymentIntentServiceGrpc::newBlockingStub);
+
+        ProviderServer server = startProviderServer(config, networkClient, paymentIntentClient);
 
         // Step 1.1 is done. You successfully initialised starter template
 
@@ -57,7 +65,7 @@ public class Main {
 
         // TODO: Step 1.3 Replace publishQuotes with your own quote publishing logic
 
-        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
         scheduler.scheduleAtFixedRate(
                 () -> PublishQuotes.publish(networkClient.stub()),
                 0, config.quotePublishingIntervalMs(), TimeUnit.MILLISECONDS);
@@ -65,7 +73,25 @@ public class Main {
         // TODO: Step 1.4 Verify that quotes for target currency are successfully received
         GetQuote.fetch(networkClient.stub());
 
-        waitForShutdown(server, scheduler, networkClient);
+        // ──────────────────────────────────────────────────────────────
+        // Payment Intent Flow — Phase 3
+        //
+        // Implement the role that applies to you. See the README for details.
+        // ──────────────────────────────────────────────────────────────
+
+        // Phase 3A — Pay-In Provider role. Comment out if you are only a beneficiary.
+        // TODO: Step 3A.1 Replace with your own pay-in quote publishing logic
+        scheduler.scheduleAtFixedRate(
+                () -> PublishPaymentIntentQuotes.publish(paymentIntentClient.stub()),
+                0, config.quotePublishingIntervalMs(), TimeUnit.MILLISECONDS);
+
+        // Phase 3B — Beneficiary Provider role. Comment out if you are only a pay-in provider.
+        // TODO: Step 3B.1 Check that indicative quotes are being returned
+        GetPaymentIntentQuote.fetch(paymentIntentClient.stub());
+        // TODO: Step 3B.2 Create a payment intent for a real end-user when they want to pay
+        // CreatePaymentIntent.create(paymentIntentClient.stub());
+
+        waitForShutdown(server, scheduler, networkClient, paymentIntentClient);
 
         // TODO: Step 2.2 Deploy your integration and provide t-0 team with the base URL
         // TODO: Step 2.3 Test payment submission (see SubmitPayment.java)
@@ -100,12 +126,19 @@ public class Main {
 
     private static ProviderServer startProviderServer(
             Config config,
-            BlockingNetworkClient<NetworkServiceGrpc.NetworkServiceBlockingStub> networkClient) {
+            BlockingNetworkClient<NetworkServiceGrpc.NetworkServiceBlockingStub> networkClient,
+            BlockingNetworkClient<PaymentIntentServiceGrpc.PaymentIntentServiceBlockingStub> paymentIntentClient) {
         try {
-            PaymentHandler handler = new PaymentHandler(networkClient.stub());
+            PaymentHandler paymentHandler = new PaymentHandler(networkClient.stub());
+            PaymentIntentPayInHandler payInHandler = new PaymentIntentPayInHandler(paymentIntentClient.stub());
+            PaymentIntentBeneficiaryHandler beneficiaryHandler = new PaymentIntentBeneficiaryHandler();
 
             ProviderServer server = ProviderServer.create(config.port(), config.networkPublicKey())
-                    .withService(handler)
+                    .withService(paymentHandler)
+                    // Phase 3A — Pay-In Provider role. Remove if you are only a beneficiary.
+                    .withService(payInHandler)
+                    // Phase 3B — Beneficiary Provider role. Remove if you are only a pay-in provider.
+                    .withService(beneficiaryHandler)
                     .start();
 
             log.info("Step 1.1: Provider server initialized on port {}", server.getPort());
@@ -120,16 +153,19 @@ public class Main {
     private static void waitForShutdown(
             ProviderServer server,
             ScheduledExecutorService scheduler,
-            BlockingNetworkClient<NetworkServiceGrpc.NetworkServiceBlockingStub> networkClient) {
+            BlockingNetworkClient<NetworkServiceGrpc.NetworkServiceBlockingStub> networkClient,
+            BlockingNetworkClient<PaymentIntentServiceGrpc.PaymentIntentServiceBlockingStub> paymentIntentClient) {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             log.info("Shutting down...");
             scheduler.shutdown();
             server.shutdown();
             networkClient.shutdown();
+            paymentIntentClient.shutdown();
             try {
                 scheduler.awaitTermination(10, TimeUnit.SECONDS);
                 server.awaitTermination(10, TimeUnit.SECONDS);
                 networkClient.awaitTermination(10, TimeUnit.SECONDS);
+                paymentIntentClient.awaitTermination(10, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/java/starter/template/src/main/java/network/t0/provider/handler/PaymentIntentBeneficiaryHandler.java
+++ b/java/starter/template/src/main/java/network/t0/provider/handler/PaymentIntentBeneficiaryHandler.java
@@ -1,0 +1,45 @@
+package network.t0.provider.handler;
+
+import io.grpc.stub.StreamObserver;
+import network.t0.sdk.proto.tzero.v1.payment_intent.BeneficiaryServiceGrpc;
+import network.t0.sdk.proto.tzero.v1.payment_intent.PaymentIntentUpdateRequest;
+import network.t0.sdk.proto.tzero.v1.payment_intent.PaymentIntentUpdateResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Payment Intent Flow — Beneficiary Provider role.
+ *
+ * <p>Implement this handler if you are a beneficiary provider (you receive settlement
+ * for the crypto side). Please refer to docs and proto definition comments to
+ * understand the full flow.
+ */
+public class PaymentIntentBeneficiaryHandler extends BeneficiaryServiceGrpc.BeneficiaryServiceImplBase {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentIntentBeneficiaryHandler.class);
+
+    /**
+     * TODO: Step 3B.3 Implement how you handle notifications about your payment intents.
+     *
+     * <p>The network calls this endpoint when the status of one of your payment intents
+     * changes (e.g. funds received from the end-user). Correlate request.getPaymentIntentId()
+     * with the id you stored after calling CreatePaymentIntent and update your
+     * internal state accordingly.
+     */
+    @Override
+    public void paymentIntentUpdate(PaymentIntentUpdateRequest request, StreamObserver<PaymentIntentUpdateResponse> responseObserver) {
+        switch (request.getUpdateCase()) {
+            case FUNDS_RECEIVED -> {
+                var fundsReceived = request.getFundsReceived();
+                log.info("payment intent {}: funds received, payment_method={} transaction_reference={}",
+                        request.getPaymentIntentId(),
+                        fundsReceived.getPaymentMethod(),
+                        fundsReceived.getTransactionReference());
+            }
+            default -> log.info("payment intent {}: unknown update variant", request.getPaymentIntentId());
+        }
+
+        responseObserver.onNext(PaymentIntentUpdateResponse.newBuilder().build());
+        responseObserver.onCompleted();
+    }
+}

--- a/java/starter/template/src/main/java/network/t0/provider/handler/PaymentIntentPayInHandler.java
+++ b/java/starter/template/src/main/java/network/t0/provider/handler/PaymentIntentPayInHandler.java
@@ -1,0 +1,49 @@
+package network.t0.provider.handler;
+
+import io.grpc.stub.StreamObserver;
+import network.t0.sdk.proto.tzero.v1.payment_intent.GetPaymentDetailsRequest;
+import network.t0.sdk.proto.tzero.v1.payment_intent.GetPaymentDetailsResponse;
+import network.t0.sdk.proto.tzero.v1.payment_intent.PayInProviderServiceGrpc;
+import network.t0.sdk.proto.tzero.v1.payment_intent.PaymentIntentServiceGrpc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Payment Intent Flow — Pay-In Provider role.
+ *
+ * <p>Implement this handler if you are a pay-in provider (you receive fiat from end-users).
+ * Please refer to docs and proto definition comments to understand the full flow.
+ */
+public class PaymentIntentPayInHandler extends PayInProviderServiceGrpc.PayInProviderServiceImplBase {
+
+    private static final Logger log = LoggerFactory.getLogger(PaymentIntentPayInHandler.class);
+
+    private final PaymentIntentServiceGrpc.PaymentIntentServiceBlockingStub paymentIntentClient;
+
+    public PaymentIntentPayInHandler(PaymentIntentServiceGrpc.PaymentIntentServiceBlockingStub paymentIntentClient) {
+        this.paymentIntentClient = paymentIntentClient;
+    }
+
+    /**
+     * TODO: Step 3A.2 Implement how you return payment details for the end-user.
+     *
+     * <p>The network calls this endpoint during CreatePaymentIntent processing. Return
+     * payment details (bank account, mobile money number, etc.) for each requested
+     * payment method, including a unique payment reference that will let you match
+     * the incoming fiat payment back to this payment intent.
+     *
+     * <p>Store (payment_intent_id, confirmation_code) so you can validate it later in
+     * ConfirmFundsReceived.
+     */
+    @Override
+    public void getPaymentDetails(GetPaymentDetailsRequest request, StreamObserver<GetPaymentDetailsResponse> responseObserver) {
+        log.info("Received getPaymentDetails for payment_intent_id={}, {} method(s)",
+                request.getPaymentIntentId(), request.getPaymentMethodsCount());
+
+        // Example: return an empty Details response — replace with your real payment instructions.
+        responseObserver.onNext(GetPaymentDetailsResponse.newBuilder()
+                .setDetails(GetPaymentDetailsResponse.Details.newBuilder().build())
+                .build());
+        responseObserver.onCompleted();
+    }
+}

--- a/java/starter/template/src/main/java/network/t0/provider/internal/ConfirmFundsReceived.java
+++ b/java/starter/template/src/main/java/network/t0/provider/internal/ConfirmFundsReceived.java
@@ -1,0 +1,48 @@
+package network.t0.provider.internal;
+
+import network.t0.sdk.proto.tzero.v1.common.PaymentMethodType;
+import network.t0.sdk.proto.tzero.v1.payment_intent.ConfirmFundsReceivedRequest;
+import network.t0.sdk.proto.tzero.v1.payment_intent.ConfirmFundsReceivedResponse;
+import network.t0.sdk.proto.tzero.v1.payment_intent.PaymentIntentServiceGrpc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Pay-In Provider role — Step 3A.3.
+ *
+ * <p>Notifies the t-0 Network that an end-user has paid. Call this after you have
+ * matched an incoming fiat payment to a payment intent (using the payment reference
+ * you returned from GetPaymentDetails). Settlement with the beneficiary provider
+ * will proceed once this confirmation is accepted.
+ */
+public class ConfirmFundsReceived {
+
+    private static final Logger log = LoggerFactory.getLogger(ConfirmFundsReceived.class);
+
+    public static void confirm(
+            PaymentIntentServiceGrpc.PaymentIntentServiceBlockingStub paymentIntentClient,
+            long paymentIntentId,
+            String confirmationCode,
+            String transactionReference) {
+        try {
+            ConfirmFundsReceivedResponse response = paymentIntentClient.confirmFundsReceived(
+                    ConfirmFundsReceivedRequest.newBuilder()
+                            .setPaymentIntentId(paymentIntentId)
+                            .setConfirmationCode(confirmationCode)
+                            .setPaymentMethod(PaymentMethodType.PAYMENT_METHOD_TYPE_SEPA)
+                            .setTransactionReference(transactionReference)
+                            // optional: if your provider has multiple legal entities,
+                            // set setOriginatorProviderLegalEntityId()
+                            .build());
+
+            switch (response.getResultCase()) {
+                case ACCEPT -> log.info("Funds accepted for payment intent {}", paymentIntentId);
+                case REJECT -> log.info("Funds rejected for payment intent {}: {}",
+                        paymentIntentId, response.getReject().getReason());
+                default -> log.info("Unknown response type");
+            }
+        } catch (io.grpc.StatusRuntimeException e) {
+            log.error("Error confirming funds received: {} - {}", e.getStatus().getCode(), e.getMessage());
+        }
+    }
+}

--- a/java/starter/template/src/main/java/network/t0/provider/internal/CreatePaymentIntent.java
+++ b/java/starter/template/src/main/java/network/t0/provider/internal/CreatePaymentIntent.java
@@ -1,0 +1,49 @@
+package network.t0.provider.internal;
+
+import network.t0.sdk.proto.ivms101.Person;
+import network.t0.sdk.proto.tzero.v1.common.Decimal;
+import network.t0.sdk.proto.tzero.v1.payment_intent.CreatePaymentIntentRequest;
+import network.t0.sdk.proto.tzero.v1.payment_intent.CreatePaymentIntentResponse;
+import network.t0.sdk.proto.tzero.v1.payment_intent.PaymentIntentServiceGrpc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+/**
+ * Beneficiary Provider role — Step 3B.2.
+ *
+ * <p>Initiates a new payment intent with the t-0 Network. Store the returned
+ * payment_intent_id to correlate with the PaymentIntentUpdate notification you'll
+ * receive on your BeneficiaryService handler once the end-user completes the pay-in.
+ */
+public class CreatePaymentIntent {
+
+    private static final Logger log = LoggerFactory.getLogger(CreatePaymentIntent.class);
+
+    public static void create(PaymentIntentServiceGrpc.PaymentIntentServiceBlockingStub paymentIntentClient) {
+        try {
+            CreatePaymentIntentResponse response = paymentIntentClient.createPaymentIntent(
+                    CreatePaymentIntentRequest.newBuilder()
+                            .setExternalReference(UUID.randomUUID().toString()) // idempotency key
+                            .setCurrency("EUR")
+                            .setAmount(Decimal.newBuilder().setUnscaled(500).setExponent(0).build()) // 500 EUR
+                            .setTravelRuleData(CreatePaymentIntentRequest.TravelRuleData.newBuilder()
+                                    // TODO: populate real IVMS101 beneficiary information for your end-user.
+                                    .addBeneficiary(Person.newBuilder().build())
+                                    .build())
+                            .build());
+
+            switch (response.getResultCase()) {
+                case SUCCESS -> log.info("Created payment intent id={} with {} pay-in option(s)",
+                        response.getSuccess().getPaymentIntentId(),
+                        response.getSuccess().getPayInDetailsCount());
+                case FAILURE -> log.info("Failed to create payment intent: {}",
+                        response.getFailure().getReason());
+                default -> log.info("Unknown response type");
+            }
+        } catch (io.grpc.StatusRuntimeException e) {
+            log.error("Error creating payment intent: {} - {}", e.getStatus().getCode(), e.getMessage());
+        }
+    }
+}

--- a/java/starter/template/src/main/java/network/t0/provider/internal/GetPaymentIntentQuote.java
+++ b/java/starter/template/src/main/java/network/t0/provider/internal/GetPaymentIntentQuote.java
@@ -1,0 +1,39 @@
+package network.t0.provider.internal;
+
+import network.t0.sdk.proto.tzero.v1.common.Decimal;
+import network.t0.sdk.proto.tzero.v1.payment_intent.GetQuoteRequest;
+import network.t0.sdk.proto.tzero.v1.payment_intent.GetQuoteResponse;
+import network.t0.sdk.proto.tzero.v1.payment_intent.PaymentIntentServiceGrpc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Beneficiary Provider role — Step 3B.1.
+ *
+ * <p>Fetches indicative quotes for a pay-in currency/amount. Use this to check
+ * available rates before creating a payment intent. The actual settlement rate is
+ * determined when the pay-in provider confirms funds received.
+ */
+public class GetPaymentIntentQuote {
+
+    private static final Logger log = LoggerFactory.getLogger(GetPaymentIntentQuote.class);
+
+    public static void fetch(PaymentIntentServiceGrpc.PaymentIntentServiceBlockingStub paymentIntentClient) {
+        try {
+            GetQuoteResponse response = paymentIntentClient.getQuote(GetQuoteRequest.newBuilder()
+                    .setCurrency("EUR")
+                    .setAmount(Decimal.newBuilder().setUnscaled(500).setExponent(0).build()) // 500 EUR
+                    .build());
+
+            switch (response.getResultCase()) {
+                case SUCCESS -> log.info("Got {} best pay-in quotes and {} total quotes",
+                        response.getSuccess().getBestQuotesCount(),
+                        response.getSuccess().getAllQuotesCount());
+                case QUOTE_NOT_FOUND -> log.info("No pay-in quotes available for this currency/amount");
+                default -> log.info("Unknown response type");
+            }
+        } catch (io.grpc.StatusRuntimeException e) {
+            log.error("Error getting payment intent quote: {} - {}", e.getStatus().getCode(), e.getMessage());
+        }
+    }
+}

--- a/java/starter/template/src/main/java/network/t0/provider/internal/PublishPaymentIntentQuotes.java
+++ b/java/starter/template/src/main/java/network/t0/provider/internal/PublishPaymentIntentQuotes.java
@@ -1,0 +1,70 @@
+package network.t0.provider.internal;
+
+import com.google.protobuf.Timestamp;
+import network.t0.sdk.proto.tzero.v1.common.Decimal;
+import network.t0.sdk.proto.tzero.v1.common.PaymentMethodType;
+import network.t0.sdk.proto.tzero.v1.payment_intent.PaymentIntentServiceGrpc;
+import network.t0.sdk.proto.tzero.v1.payment_intent.UpdateQuoteRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Pay-In Provider role — Step 3A.1.
+ *
+ * <p>Publishes pay-in quotes for the payment intent flow. These quotes tell the
+ * network what exchange rates you're willing to accept when an end-user pays via
+ * one of your supported payment methods.
+ *
+ * <p>TODO: Step 3A.1 replace this with fetching pay-in quotes from your systems
+ * and publishing them into t-0 Network. We recommend publishing at least once per
+ * 5 seconds, but not more than once per second.
+ */
+public class PublishPaymentIntentQuotes {
+
+    private static final Logger log = LoggerFactory.getLogger(PublishPaymentIntentQuotes.class);
+
+    public static void publish(PaymentIntentServiceGrpc.PaymentIntentServiceBlockingStub paymentIntentClient) {
+        try {
+            Instant now = Instant.now();
+            Timestamp expiration = Timestamp.newBuilder()
+                    .setSeconds(now.plusSeconds(30).getEpochSecond())
+                    .setNanos(now.plusSeconds(30).getNano())
+                    .build();
+            Timestamp timestamp = Timestamp.newBuilder()
+                    .setSeconds(now.getEpochSecond())
+                    .setNanos(now.getNano())
+                    .build();
+
+            // NOTE: Every UpdateQuote request discards all previous payment intent quotes
+            // that were published before. Combine multiple quotes into a single request.
+            paymentIntentClient.updateQuote(UpdateQuoteRequest.newBuilder()
+                    .addPaymentIntentQuotes(UpdateQuoteRequest.Quote.newBuilder()
+                            .setCurrency("EUR")
+                            .setPaymentMethod(PaymentMethodType.PAYMENT_METHOD_TYPE_SEPA)
+                            .setExpiration(expiration)
+                            .setTimestamp(timestamp)
+                            .addBands(UpdateQuoteRequest.Quote.Band.newBuilder()
+                                    .setClientQuoteId(UUID.randomUUID().toString())
+                                    .setMaxAmount(Decimal.newBuilder()
+                                            .setUnscaled(1000) // max 1000 USD for this band
+                                            .setExponent(0)
+                                            .build())
+                                    // rate is always USD/XXX, so for EUR quote should be USD/EUR
+                                    .setRate(Decimal.newBuilder()
+                                            .setUnscaled(92) // rate 0.92
+                                            .setExponent(-2)
+                                            .build())
+                                    .build())
+                            .build())
+                    .build());
+
+            log.debug("✅ Payment intent quotes published successfully");
+
+        } catch (io.grpc.StatusRuntimeException e) {
+            log.error("Error updating payment intent quote: {} - {}", e.getStatus().getCode(), e.getMessage());
+        }
+    }
+}

--- a/node/sdk/src/index.ts
+++ b/node/sdk/src/index.ts
@@ -11,5 +11,8 @@ export * from './common/gen/tzero/v1/common/payment_method_pb.js'
 export * from './common/gen/tzero/v1/payment/provider_pb.js'
 export * from './common/gen/tzero/v1/payment/network_pb.js'
 
+export * as PaymentIntentNetwork from './common/gen/tzero/v1/payment_intent/network_pb.js'
+export * as PaymentIntentPayInProvider from './common/gen/tzero/v1/payment_intent/pay_in_provider_pb.js'
+export * as PaymentIntentBeneficiary from './common/gen/tzero/v1/payment_intent/beneficiary_pb.js'
 export * as PaymentIntentProvider from './common/gen/tzero/v1/payment_intent/provider/provider_pb.js'
 export * as PaymentIntentRecipient from './common/gen/tzero/v1/payment_intent/recipient/recipient_pb.js'

--- a/node/starter/README.md
+++ b/node/starter/README.md
@@ -15,19 +15,25 @@ The CLI will prompt for a project name, then create a ready-to-run project with 
 ```
 your-project-name/
 ├── src/
-│   ├── index.ts              # Entry point
-│   ├── service.ts            # Provider service implementation
-│   ├── publish_quotes.ts     # Quote publishing logic
-│   ├── get_quote.ts          # Quote retrieval logic
-│   ├── submit_payment.ts     # Payment submission logic
-│   └── lib.ts                # Utility functions
-├── Dockerfile                # Docker configuration
-├── .env                      # Environment variables (with generated keys)
-├── .env.example              # Example environment file
-├── .eslintrc.json            # ESLint configuration
-├── .gitignore                # Git ignore rules
-├── package.json              # Project dependencies
-└── tsconfig.json             # TypeScript configuration
+│   ├── index.ts                                  # Entry point
+│   ├── service.ts                                # Phase 2: ProviderService handlers
+│   ├── payment_intent_pay_in_service.ts          # Phase 3A: PayInProviderService handler
+│   ├── payment_intent_beneficiary_service.ts     # Phase 3B: BeneficiaryService handler
+│   ├── publish_quotes.ts                         # Phase 1: payout quote publishing
+│   ├── get_quote.ts                              # Phase 1: quote retrieval
+│   ├── publish_payment_intent_quotes.ts          # Phase 3A: pay-in quote publishing
+│   ├── get_payment_intent_quote.ts               # Phase 3B: indicative quote retrieval
+│   ├── create_payment_intent.ts                  # Phase 3B: create a payment intent
+│   ├── confirm_funds_received.ts                 # Phase 3A: confirm funds received
+│   ├── submit_payment.ts                         # Phase 2: payment submission
+│   └── lib.ts                                    # Utility functions
+├── Dockerfile                                    # Docker configuration
+├── .env                                          # Environment variables (with generated keys)
+├── .env.example                                  # Example environment file
+├── .eslintrc.json                                # ESLint configuration
+├── .gitignore                                    # Git ignore rules
+├── package.json                                  # Project dependencies
+└── tsconfig.json                                 # TypeScript configuration
 ```
 
 ## Key Files to Modify
@@ -63,6 +69,26 @@ your-project-name/
 3. Implement `payOut` handler in `src/service.ts`.
 4. Test payment submission by uncommenting the `submitPayment` call in `src/index.ts`.
 5. Coordinate with the T-0 team to test end-to-end payment flows.
+
+### Phase 3: Payment Intent Flow
+
+The payment intent flow is independent of Phase 2. It is an asynchronous pay-in flow where an end-user pays a pay-in provider in fiat (bank transfer, mobile money, etc.) and a beneficiary provider receives settlement on the crypto side. Quotes are indicative until funds are received, settlement happens periodically, and a confirmation code links the end-user's payment back to a specific payment intent.
+
+Implement **one** of the two sub-phases below depending on your role. If you participate on both sides, implement both.
+
+**Phase 3A -- Pay-In Provider role** (skip if you're a beneficiary):
+
+1. **Step 3A.1** Replace the sample pay-in quote publishing in `src/publish_payment_intent_quotes.ts` with your own.
+2. **Step 3A.2** Implement `getPaymentDetails` in `src/payment_intent_pay_in_service.ts` -- return bank account / mobile money details plus a payment reference the end-user will include in their transfer.
+3. **Step 3A.3** When you detect the end-user's fiat payment, call `confirmFundsReceived` (see `src/confirm_funds_received.ts`).
+
+**Phase 3B -- Beneficiary Provider role** (skip if you're pay-in):
+
+1. **Step 3B.1** Verify indicative quotes are returned (`src/get_payment_intent_quote.ts`).
+2. **Step 3B.2** Create payment intents for your end-users via `createPaymentIntent` (see `src/create_payment_intent.ts`).
+3. **Step 3B.3** Implement `paymentIntentUpdate` in `src/payment_intent_beneficiary_service.ts` to receive notifications when funds are received.
+
+If you only play one role, delete the files for the other role and remove the corresponding `r.service(...)` registration in `src/index.ts`.
 
 ## Available Commands
 

--- a/node/starter/template/src/confirm_funds_received.ts
+++ b/node/starter/template/src/confirm_funds_received.ts
@@ -1,0 +1,31 @@
+import {type Client, PaymentIntentNetwork, PaymentMethodType} from "@t-0/provider-sdk";
+
+export default async function confirmFundsReceived(
+    paymentIntentClient: Client<typeof PaymentIntentNetwork.PaymentIntentService>,
+    paymentIntentId: bigint,
+    confirmationCode: string,
+    transactionReference: string,
+) {
+  // Pay-In Provider role — Step 3A.3.
+  // Call this after you have matched an incoming fiat payment to a payment intent
+  // (using the payment reference you returned from getPaymentDetails). Settlement
+  // with the beneficiary provider will proceed once this confirmation is accepted.
+  const response = await paymentIntentClient.confirmFundsReceived({
+    paymentIntentId,
+    confirmationCode,
+    paymentMethod: PaymentMethodType.SEPA,
+    transactionReference,
+    // optional: if your provider has multiple legal entities, set originatorProviderLegalEntityId
+  })
+
+  switch (response.Result.case) {
+    case 'accept':
+      console.log(`Funds accepted for payment intent ${paymentIntentId}`)
+      break;
+    case 'reject':
+      console.log(`Funds rejected for payment intent ${paymentIntentId}: ${response.Result.value.reason}`)
+      break;
+    default:
+      console.error("unexpected result type")
+  }
+}

--- a/node/starter/template/src/create_payment_intent.ts
+++ b/node/starter/template/src/create_payment_intent.ts
@@ -1,0 +1,37 @@
+import {type Client, PaymentIntentNetwork} from "@t-0/provider-sdk";
+import {toProtoDecimal} from "./lib";
+import {randomUUID} from "node:crypto";
+
+export default async function createPaymentIntent(
+    paymentIntentClient: Client<typeof PaymentIntentNetwork.PaymentIntentService>,
+) {
+  // Beneficiary Provider role — Step 3B.2.
+  // Store the returned paymentIntentId to correlate with the PaymentIntentUpdate
+  // notification you'll receive on your BeneficiaryService handler once the end-user
+  // completes the pay-in.
+  const response = await paymentIntentClient.createPaymentIntent({
+    externalReference: randomUUID(), // idempotency key — reuse to retry without duplicating the intent
+    currency: 'EUR',
+    amount: toProtoDecimal(500, 0), // end-user pays 500 EUR
+    travelRuleData: {
+      // TODO: populate real IVMS101 beneficiary information for your end-user.
+      beneficiary: [{}],
+    },
+  })
+
+  switch (response.Result.case) {
+    case 'success':
+      console.log(
+          `Created payment intent id=${response.Result.value.paymentIntentId}`,
+          `with ${response.Result.value.payInDetails.length} pay-in option(s)`,
+      )
+      // TODO: persist (paymentIntentId, externalReference) and present the
+      // payInDetails options to your end-user.
+      break;
+    case 'failure':
+      console.log(`Failed to create payment intent: ${response.Result.value.reason}`)
+      break;
+    default:
+      console.error("unexpected result type")
+  }
+}

--- a/node/starter/template/src/get_payment_intent_quote.ts
+++ b/node/starter/template/src/get_payment_intent_quote.ts
@@ -1,0 +1,28 @@
+import {type Client, PaymentIntentNetwork} from "@t-0/provider-sdk";
+import {toProtoDecimal} from "./lib";
+
+export default async function getPaymentIntentQuote(
+    paymentIntentClient: Client<typeof PaymentIntentNetwork.PaymentIntentService>,
+) {
+  // Beneficiary Provider role — Step 3B.1.
+  // Use this to check available rates before creating a payment intent. The actual
+  // settlement rate is determined when the pay-in provider confirms funds received.
+  const response = await paymentIntentClient.getQuote({
+    currency: "EUR",
+    amount: toProtoDecimal(500, 0), // end-user pays 500 EUR
+  })
+
+  switch (response.Result.case) {
+    case 'success':
+      console.log(
+          `Got ${response.Result.value.bestQuotes.length} best pay-in quotes`,
+          `and ${response.Result.value.allQuotes.length} total quotes`,
+      )
+      break;
+    case 'quoteNotFound':
+      console.log("No pay-in quotes available for this currency/amount")
+      break;
+    default:
+      console.error("unexpected result type")
+  }
+}

--- a/node/starter/template/src/index.ts
+++ b/node/starter/template/src/index.ts
@@ -4,6 +4,9 @@ import {
   createService,
   NetworkService,
   nodeAdapter,
+  PaymentIntentBeneficiary,
+  PaymentIntentNetwork,
+  PaymentIntentPayInProvider,
   ProviderService,
   signatureValidation,
 } from "@t-0/provider-sdk";
@@ -14,6 +17,12 @@ import CreateProviderService from "./service";
 import getQuote from "./get_quote";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import submitPayment from "./submit_payment";
+import CreatePayInProviderService from "./payment_intent_pay_in_service";
+import CreateBeneficiaryService from "./payment_intent_beneficiary_service";
+import publishPaymentIntentQuotes from "./publish_payment_intent_quotes";
+import getPaymentIntentQuote from "./get_payment_intent_quote";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import createPaymentIntent from "./create_payment_intent";
 
 dotenv.config();
 
@@ -32,14 +41,22 @@ async function main() {
   console.log(`📡 Port: ${port}`);
   console.log(`🔑 Network Public Key: ${networkPublicKeyHex}`);
   const networkClient = createClient(privateKeyHex!, endpoint, NetworkService);
+  const paymentIntentClient = createClient(privateKeyHex!, endpoint, PaymentIntentNetwork.PaymentIntentService);
 
   await publishQuotes(networkClient, quotePublishingInterval)
+
+  // Phase 3A — Pay-In Provider role. Comment out if you are only a beneficiary.
+  await publishPaymentIntentQuotes(paymentIntentClient, quotePublishingInterval)
 
   const server = http.createServer(
     signatureValidation(
       nodeAdapter(
         createService(networkPublicKeyHex!, (r) => {
           r.service(ProviderService, CreateProviderService(networkClient));
+          // Phase 3A — Pay-In Provider role. Remove if you are only a beneficiary.
+          r.service(PaymentIntentPayInProvider.PayInProviderService, CreatePayInProviderService(paymentIntentClient));
+          // Phase 3B — Beneficiary Provider role. Remove if you are only a pay-in provider.
+          r.service(PaymentIntentBeneficiary.BeneficiaryService, CreateBeneficiaryService());
         })))
   ).listen(port);
   console.log("✅ Service ready and is listening at", server.address());
@@ -59,10 +76,21 @@ async function main() {
   // await submitPayment(networkClient)
 
   // TODO: Step 2.5 ask t-0 team to submit a payment which would trigger your payOut endpoint
+
+  // ──────────────────────────────────────────────────────────────
+  // Payment Intent Flow — Phase 3
+  //
+  // Implement the role that applies to you. See the README for details.
+  // ──────────────────────────────────────────────────────────────
+
+  // Phase 3B — Beneficiary Provider role. Comment out if you are only a pay-in provider.
+  // TODO: Step 3B.1 check that indicative quotes are returned
+  await getPaymentIntentQuote(paymentIntentClient)
+  // TODO: Step 3B.2 create a payment intent for a real end-user when they want to pay
+  // await createPaymentIntent(paymentIntentClient)
 }
 
 main().catch((error) => {
   console.error('❌ Error starting service:', error);
   process.exit(1);
 });
-

--- a/node/starter/template/src/payment_intent_beneficiary_service.ts
+++ b/node/starter/template/src/payment_intent_beneficiary_service.ts
@@ -1,0 +1,38 @@
+import {
+    HandlerContext,
+    PaymentIntentBeneficiary,
+} from "@t-0/provider-sdk";
+
+/*
+  Payment Intent Flow — Beneficiary Provider role.
+
+  Implement this service if you are a beneficiary provider (you receive settlement for the crypto side).
+  Please refer to docs and proto definition comments to understand the full flow.
+ */
+const CreateBeneficiaryService = () => {
+    return {
+        // TODO: Step 3B.3 Implement how you handle notifications about your payment intents.
+        //
+        // The network calls this endpoint when the status of one of your payment intents
+        // changes (e.g. funds received from the end-user). Correlate req.paymentIntentId
+        // with the id you stored after calling createPaymentIntent and update your
+        // internal state accordingly.
+        async paymentIntentUpdate(req: PaymentIntentBeneficiary.PaymentIntentUpdateRequest, _: HandlerContext) {
+            switch (req.update.case) {
+                case 'fundsReceived':
+                    console.log(
+                        `Payment intent ${req.paymentIntentId}: funds received,`,
+                        `settlementAmount=${JSON.stringify(req.update.value.settlementAmount)},`,
+                        `paymentMethod=${req.update.value.paymentMethod},`,
+                        `transactionReference=${req.update.value.transactionReference}`,
+                    )
+                    break;
+                default:
+                    console.log(`Payment intent ${req.paymentIntentId}: unknown update variant`)
+            }
+            return {} as PaymentIntentBeneficiary.PaymentIntentUpdateResponse
+        },
+    }
+};
+
+export default CreateBeneficiaryService;

--- a/node/starter/template/src/payment_intent_pay_in_service.ts
+++ b/node/starter/template/src/payment_intent_pay_in_service.ts
@@ -1,0 +1,39 @@
+import {
+    type Client,
+    HandlerContext,
+    PaymentIntentNetwork,
+    PaymentIntentPayInProvider,
+} from "@t-0/provider-sdk";
+
+/*
+  Payment Intent Flow — Pay-In Provider role.
+
+  Implement this service if you are a pay-in provider (you receive fiat from end-users).
+  Please refer to docs and proto definition comments to understand the full flow.
+ */
+const CreatePayInProviderService = (paymentIntentClient: Client<typeof PaymentIntentNetwork.PaymentIntentService>) => {
+    return {
+        // TODO: Step 3A.2 Implement how you return payment details for the end-user.
+        //
+        // The network calls this endpoint during CreatePaymentIntent processing. Return
+        // payment details (bank account, mobile money number, etc.) for each requested
+        // paymentMethod, including a unique payment reference that will let you match
+        // the incoming fiat payment back to this payment intent.
+        //
+        // Store (paymentIntentId, confirmationCode) so you can validate it later in
+        // confirmFundsReceived.
+        async getPaymentDetails(req: PaymentIntentPayInProvider.GetPaymentDetailsRequest, _: HandlerContext) {
+            console.log(`Received GetPaymentDetails for payment intent ${req.paymentIntentId}, methods: ${req.paymentMethods.join(',')}`)
+            return {
+                result: {
+                    case: 'details',
+                    value: {
+                        paymentDetails: [], // TODO: populate one PaymentDetails per requested paymentMethod
+                    },
+                },
+            } as unknown as PaymentIntentPayInProvider.GetPaymentDetailsResponse
+        },
+    }
+};
+
+export default CreatePayInProviderService;

--- a/node/starter/template/src/publish_payment_intent_quotes.ts
+++ b/node/starter/template/src/publish_payment_intent_quotes.ts
@@ -1,0 +1,39 @@
+import {type Client, PaymentIntentNetwork, PaymentMethodType} from "@t-0/provider-sdk";
+import {toProtoDecimal} from "./lib";
+import {randomUUID} from "node:crypto";
+import {timestampFromDate} from "@bufbuild/protobuf/wkt";
+
+export default async function publishPaymentIntentQuotes(
+    paymentIntentClient: Client<typeof PaymentIntentNetwork.PaymentIntentService>,
+    quotePublishingInterval: number,
+): Promise<void> {
+  // TODO: Step 3A.1 replace this with fetching pay-in quotes from your systems and publishing them into t-0 Network.
+  // We recommend publishing at least once per 5 seconds, but not more than once per second.
+  const tick = async () => {
+    try {
+      // NOTE: Every updateQuote request discards all previous payment intent quotes
+      // that were published before. Combine multiple quotes into a single request.
+      await paymentIntentClient.updateQuote({
+        paymentIntentQuotes: [{
+          currency: 'EUR',
+          paymentMethod: PaymentMethodType.SEPA,
+          expiration: timestampFromDate(new Date(Date.now() + 30 * 1000)), // 30 seconds from now
+          timestamp: timestampFromDate(new Date()),
+          bands: [{
+            clientQuoteId: randomUUID(),
+            maxAmount: toProtoDecimal(1000, 0), // max 1000 USD for this band
+            // rate is always USD/XXX, so for EUR quote should be USD/EUR
+            rate: toProtoDecimal(92, -2), // rate 0.92
+          }],
+        }],
+      })
+    } catch (error) {
+      console.error(error);
+      return
+    }
+    console.log("payment intent quote published")
+  }
+
+  await tick()
+  setInterval(tick, quotePublishingInterval);
+}

--- a/python/README.md
+++ b/python/README.md
@@ -31,20 +31,28 @@ t0-provider-starter <project_name> [-d <directory>]
 
 ```
 my_provider/
-├── pyproject.toml              # Project metadata, depends on t0-provider-sdk
-├── Dockerfile                  # Multi-stage build with python:3.13-slim
-├── .env.example                # Template environment file
-├── .env                        # Generated with your private key (git-ignored)
+├── pyproject.toml                              # Project metadata, depends on t0-provider-sdk
+├── Dockerfile                                  # Multi-stage build with python:3.13-slim
+├── .env.example                                # Template environment file
+├── .env                                        # Generated with your private key (git-ignored)
 └── src/provider/
     ├── __init__.py
-    ├── main.py                 # Entry point: server, quote publishing, quote retrieval
-    ├── config.py               # Environment variable loading and validation
-    ├── publish_quotes.py       # Sample quote publishing loop
-    ├── get_quote.py            # Sample quote retrieval
+    ├── main.py                                 # Entry point: server, quote tasks, handlers
+    ├── config.py                               # Environment variable loading and validation
+    ├── publish_quotes.py                       # Phase 1: payout quote publishing
+    ├── get_quote.py                            # Phase 1: quote retrieval
+    ├── publish_payment_intent_quotes.py        # Phase 3A: pay-in quote publishing
+    ├── get_payment_intent_quote.py             # Phase 3B: indicative quote retrieval
+    ├── create_payment_intent.py                # Phase 3B: create a payment intent
+    ├── confirm_funds_received.py               # Phase 3A: confirm funds received
     └── handler/
         ├── __init__.py
-        ├── payment.py          # ProviderServiceImplementation (async, 5 RPC methods)
-        └── payment_sync.py     # ProviderServiceSyncImplementation (sync/WSGI variant)
+        ├── payment.py                          # Phase 2: ProviderService (async)
+        ├── payment_sync.py                     # Phase 2: ProviderService (sync/WSGI)
+        ├── payment_intent_pay_in.py            # Phase 3A: PayInProviderService (async)
+        ├── payment_intent_pay_in_sync.py       # Phase 3A: PayInProviderService (sync/WSGI)
+        ├── payment_intent_beneficiary.py       # Phase 3B: BeneficiaryService (async)
+        └── payment_intent_beneficiary_sync.py  # Phase 3B: BeneficiaryService (sync/WSGI)
 ```
 
 ## Key Files to Modify
@@ -85,6 +93,26 @@ Additional optional methods in `src/provider/handler/payment.py`:
 - `update_limit` -- handle notifications about limit changes
 - `append_ledger_entries` -- handle notifications about ledger transactions
 - `approve_payment_quotes` -- approve quotes after AML check
+
+### Phase 3: Payment Intent Flow
+
+The payment intent flow is independent of Phase 2. It is an asynchronous pay-in flow where an end-user pays a pay-in provider in fiat (bank transfer, mobile money, etc.) and a beneficiary provider receives settlement on the crypto side. Quotes are indicative until funds are received, settlement happens periodically, and a confirmation code links the end-user's payment back to a specific payment intent.
+
+Implement **one** of the two sub-phases below depending on your role. If you participate on both sides, implement both.
+
+**Phase 3A -- Pay-In Provider role** (skip if you're a beneficiary):
+
+1. **Step 3A.1** Replace the sample pay-in quote publishing in `src/provider/publish_payment_intent_quotes.py` with your own.
+2. **Step 3A.2** Implement `get_payment_details` in `src/provider/handler/payment_intent_pay_in.py` -- return bank account / mobile money details plus a payment reference the end-user will include in their transfer.
+3. **Step 3A.3** When you detect the end-user's fiat payment, call `confirm_funds_received` (see `src/provider/confirm_funds_received.py`).
+
+**Phase 3B -- Beneficiary Provider role** (skip if you're pay-in):
+
+1. **Step 3B.1** Verify indicative quotes are returned (`src/provider/get_payment_intent_quote.py`).
+2. **Step 3B.2** Create payment intents for your end-users via `create_payment_intent` (see `src/provider/create_payment_intent.py`).
+3. **Step 3B.3** Implement `payment_intent_update` in `src/provider/handler/payment_intent_beneficiary.py` to receive notifications when funds are received.
+
+If you only play one role, delete the files for the other role and remove the corresponding `handler(...)` registration in `src/provider/main.py`. Sync (WSGI) variants of both handlers are provided (`*_sync.py`) for use with the WSGI setup described below.
 
 ## Installation
 

--- a/python/starter/src/t0_provider_starter/template/src/provider/confirm_funds_received.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/confirm_funds_received.py
@@ -1,0 +1,49 @@
+"""Confirm funds received from an end-user for a payment intent.
+
+Go equivalent: internal/confirm_funds_received.go → ConfirmFundsReceived()
+
+Pay-In Provider role — Step 3A.3. Call this after you have matched an incoming
+fiat payment to a payment intent (using the payment reference you returned from
+get_payment_details). Settlement with the beneficiary provider will proceed once
+this confirmation is accepted.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from t0_provider_sdk.api.tzero.v1.common.payment_method_pb2 import PAYMENT_METHOD_TYPE_SEPA
+from t0_provider_sdk.api.tzero.v1.payment_intent.network_connect import PaymentIntentServiceClient
+from t0_provider_sdk.api.tzero.v1.payment_intent.network_pb2 import ConfirmFundsReceivedRequest
+
+logger = logging.getLogger(__name__)
+
+
+async def confirm_funds_received(
+    payment_intent_client: PaymentIntentServiceClient,
+    payment_intent_id: int,
+    confirmation_code: str,
+    transaction_reference: str,
+) -> None:
+    try:
+        response = await payment_intent_client.confirm_funds_received(
+            ConfirmFundsReceivedRequest(
+                payment_intent_id=payment_intent_id,
+                confirmation_code=confirmation_code,
+                payment_method=PAYMENT_METHOD_TYPE_SEPA,
+                transaction_reference=transaction_reference,
+                # optional: if your provider has multiple legal entities, set
+                # originator_provider_legal_entity_id
+            ),
+        )
+
+        if response.HasField("accept"):
+            logger.info("Funds accepted for payment intent %d", payment_intent_id)
+        elif response.HasField("reject"):
+            logger.info(
+                "Funds rejected for payment intent %d: %s",
+                payment_intent_id,
+                response.reject.reason,
+            )
+    except Exception:
+        logger.exception("Error confirming funds received")

--- a/python/starter/src/t0_provider_starter/template/src/provider/create_payment_intent.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/create_payment_intent.py
@@ -1,0 +1,48 @@
+"""Create a payment intent via the T-0 Network.
+
+Go equivalent: internal/create_payment_intent.go → CreatePaymentIntent()
+
+Beneficiary Provider role — Step 3B.2. Store the returned payment_intent_id to
+correlate with the PaymentIntentUpdate notification you'll receive on your
+BeneficiaryService handler once the end-user completes the pay-in.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from ivms101.v1.ivms.ivms101_pb2 import Person
+from t0_provider_sdk.api.tzero.v1.common.common_pb2 import Decimal
+from t0_provider_sdk.api.tzero.v1.payment_intent.network_connect import PaymentIntentServiceClient
+from t0_provider_sdk.api.tzero.v1.payment_intent.network_pb2 import CreatePaymentIntentRequest
+
+logger = logging.getLogger(__name__)
+
+
+async def create_payment_intent(payment_intent_client: PaymentIntentServiceClient) -> None:
+    try:
+        response = await payment_intent_client.create_payment_intent(
+            CreatePaymentIntentRequest(
+                external_reference=str(uuid.uuid4()),  # idempotency key
+                currency="EUR",
+                amount=Decimal(unscaled=500, exponent=0),  # end-user pays 500 EUR
+                travel_rule_data=CreatePaymentIntentRequest.TravelRuleData(
+                    # TODO: populate real IVMS101 beneficiary information for your end-user.
+                    beneficiary=[Person()],
+                ),
+            ),
+        )
+
+        if response.HasField("success"):
+            logger.info(
+                "Created payment intent id=%d with %d pay-in option(s)",
+                response.success.payment_intent_id,
+                len(response.success.pay_in_details),
+            )
+            # TODO: persist (payment_intent_id, external_reference) and present the
+            # pay_in_details options to your end-user.
+        elif response.HasField("failure"):
+            logger.info("Failed to create payment intent: %s", response.failure.reason)
+    except Exception:
+        logger.exception("Error creating payment intent")

--- a/python/starter/src/t0_provider_starter/template/src/provider/get_payment_intent_quote.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/get_payment_intent_quote.py
@@ -1,0 +1,41 @@
+"""Payment intent indicative quote from the T-0 Network.
+
+Go equivalent: internal/get_payment_intent_quote.go → GetPaymentIntentQuote()
+
+Beneficiary Provider role — Step 3B.1. Use this to check available rates before
+creating a payment intent. The actual settlement rate is determined when the
+pay-in provider confirms funds received.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from t0_provider_sdk.api.tzero.v1.common.common_pb2 import Decimal
+from t0_provider_sdk.api.tzero.v1.payment_intent.network_connect import PaymentIntentServiceClient
+from t0_provider_sdk.api.tzero.v1.payment_intent.network_pb2 import GetQuoteRequest
+
+logger = logging.getLogger(__name__)
+
+
+async def get_payment_intent_quote(payment_intent_client: PaymentIntentServiceClient) -> None:
+    try:
+        response = await payment_intent_client.get_quote(
+            GetQuoteRequest(
+                currency="EUR",
+                amount=Decimal(unscaled=500, exponent=0),  # end-user pays 500 EUR
+            ),
+        )
+
+        if response.HasField("success"):
+            logger.info(
+                "Got %d best pay-in quotes and %d total quotes",
+                len(response.success.best_quotes),
+                len(response.success.all_quotes),
+            )
+        elif response.HasField("quote_not_found"):
+            logger.info("No pay-in quotes available for this currency/amount")
+        else:
+            logger.info("Unknown response type")
+    except Exception:
+        logger.exception("Error getting payment intent quote")

--- a/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_intent_beneficiary.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_intent_beneficiary.py
@@ -1,0 +1,44 @@
+"""Payment Intent — Beneficiary Provider role (async).
+
+Go equivalent: internal/handler/payment_intent_beneficiary.go
+
+Implement this handler if you are a beneficiary provider (you receive settlement
+for the crypto side). Please refer to docs and proto definition comments to
+understand the full flow.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from connectrpc.request import RequestContext
+from t0_provider_sdk.api.tzero.v1.payment_intent.beneficiary_pb2 import (
+    PaymentIntentUpdateRequest,
+    PaymentIntentUpdateResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BeneficiaryServiceImplementation:
+    """Implements the BeneficiaryService protocol from the generated ConnectRPC code."""
+
+    # TODO: Step 3B.3 Implement how you handle notifications about your payment intents.
+    #
+    # The network calls this endpoint when the status of one of your payment intents
+    # changes (e.g. funds received from the end-user). Correlate request.payment_intent_id
+    # with the id you stored after calling create_payment_intent and update your
+    # internal state accordingly.
+    async def payment_intent_update(
+        self, request: PaymentIntentUpdateRequest, ctx: RequestContext
+    ) -> PaymentIntentUpdateResponse:
+        if request.HasField("funds_received"):
+            logger.info(
+                "payment intent %d: funds received, payment_method=%s transaction_reference=%s",
+                request.payment_intent_id,
+                request.funds_received.payment_method,
+                request.funds_received.transaction_reference,
+            )
+        else:
+            logger.info("payment intent %d: unknown update variant", request.payment_intent_id)
+        return PaymentIntentUpdateResponse()

--- a/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_intent_beneficiary_sync.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_intent_beneficiary_sync.py
@@ -1,0 +1,36 @@
+"""Payment Intent — Beneficiary Provider role (sync).
+
+Parallel to payment_intent_beneficiary.py but without async/await.
+Use this with handler_sync() and new_wsgi_app() for synchronous WSGI servers.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from connectrpc.request import RequestContext
+from t0_provider_sdk.api.tzero.v1.payment_intent.beneficiary_pb2 import (
+    PaymentIntentUpdateRequest,
+    PaymentIntentUpdateResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BeneficiaryServiceSyncImplementation:
+    """Implements the BeneficiaryServiceSync protocol from the generated ConnectRPC code."""
+
+    # TODO: Step 3B.3 See the async variant (payment_intent_beneficiary.py) for context.
+    def payment_intent_update(
+        self, request: PaymentIntentUpdateRequest, ctx: RequestContext
+    ) -> PaymentIntentUpdateResponse:
+        if request.HasField("funds_received"):
+            logger.info(
+                "payment intent %d: funds received, payment_method=%s transaction_reference=%s",
+                request.payment_intent_id,
+                request.funds_received.payment_method,
+                request.funds_received.transaction_reference,
+            )
+        else:
+            logger.info("payment intent %d: unknown update variant", request.payment_intent_id)
+        return PaymentIntentUpdateResponse()

--- a/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_intent_pay_in.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_intent_pay_in.py
@@ -1,0 +1,52 @@
+"""Payment Intent — Pay-In Provider role (async).
+
+Go equivalent: internal/handler/payment_intent_pay_in.go
+
+Implement this handler if you are a pay-in provider (you receive fiat from end-users).
+Please refer to docs and proto definition comments to understand the full flow.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from connectrpc.request import RequestContext
+from t0_provider_sdk.api.tzero.v1.payment_intent.network_connect import (
+    PaymentIntentServiceClient,
+)
+from t0_provider_sdk.api.tzero.v1.payment_intent.pay_in_provider_pb2 import (
+    GetPaymentDetailsRequest,
+    GetPaymentDetailsResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PayInProviderServiceImplementation:
+    """Implements the PayInProviderService protocol from the generated ConnectRPC code."""
+
+    def __init__(self, payment_intent_client: PaymentIntentServiceClient) -> None:
+        self._payment_intent_client = payment_intent_client
+
+    # TODO: Step 3A.2 Implement how you return payment details for the end-user.
+    #
+    # The network calls this endpoint during CreatePaymentIntent processing. Return
+    # payment details (bank account, mobile money number, etc.) for each requested
+    # payment method, including a unique payment reference that will let you match
+    # the incoming fiat payment back to this payment intent.
+    #
+    # Store (payment_intent_id, confirmation_code) so you can validate it later in
+    # confirm_funds_received.
+    async def get_payment_details(
+        self, request: GetPaymentDetailsRequest, ctx: RequestContext
+    ) -> GetPaymentDetailsResponse:
+        logger.info(
+            "GetPaymentDetails for payment intent %d, %d method(s)",
+            request.payment_intent_id,
+            len(request.payment_methods),
+        )
+        return GetPaymentDetailsResponse(
+            details=GetPaymentDetailsResponse.Details(
+                payment_details=[],  # TODO: populate one PaymentDetails per requested payment_method
+            ),
+        )

--- a/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_intent_pay_in_sync.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_intent_pay_in_sync.py
@@ -1,0 +1,42 @@
+"""Payment Intent — Pay-In Provider role (sync).
+
+Parallel to payment_intent_pay_in.py but without async/await.
+Use this with handler_sync() and new_wsgi_app() for synchronous WSGI servers.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from connectrpc.request import RequestContext
+from t0_provider_sdk.api.tzero.v1.payment_intent.network_connect import (
+    PaymentIntentServiceClientSync,
+)
+from t0_provider_sdk.api.tzero.v1.payment_intent.pay_in_provider_pb2 import (
+    GetPaymentDetailsRequest,
+    GetPaymentDetailsResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PayInProviderServiceSyncImplementation:
+    """Implements the PayInProviderServiceSync protocol from the generated ConnectRPC code."""
+
+    def __init__(self, payment_intent_client: PaymentIntentServiceClientSync) -> None:
+        self._payment_intent_client = payment_intent_client
+
+    # TODO: Step 3A.2 See the async variant (payment_intent_pay_in.py) for context.
+    def get_payment_details(
+        self, request: GetPaymentDetailsRequest, ctx: RequestContext
+    ) -> GetPaymentDetailsResponse:
+        logger.info(
+            "GetPaymentDetails for payment intent %d, %d method(s)",
+            request.payment_intent_id,
+            len(request.payment_methods),
+        )
+        return GetPaymentDetailsResponse(
+            details=GetPaymentDetailsResponse.Details(
+                payment_details=[],  # TODO: populate one PaymentDetails per requested payment_method
+            ),
+        )

--- a/python/starter/src/t0_provider_starter/template/src/provider/main.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/main.py
@@ -19,8 +19,10 @@ swap the following imports and use the sync variants:
     #   from t0_provider_sdk.network.client import new_service_client_sync
     #   from t0_provider_sdk.provider.handler import handler_sync, new_wsgi_app
 
-    # Use the sync handler implementation:
+    # Use the sync handler implementations:
     #   from provider.handler.payment_sync import ProviderServiceSyncImplementation
+    #   from provider.handler.payment_intent_pay_in_sync import PayInProviderServiceSyncImplementation
+    #   from provider.handler.payment_intent_beneficiary_sync import BeneficiaryServiceSyncImplementation
 
     # Build the WSGI app:
     #   network_client = new_service_client_sync(private_key, NetworkServiceClientSync, base_url=...)
@@ -40,12 +42,20 @@ import signal
 import uvicorn
 from t0_provider_sdk.api.tzero.v1.payment.network_connect import NetworkServiceClient
 from t0_provider_sdk.api.tzero.v1.payment.provider_connect import ProviderServiceASGIApplication
+from t0_provider_sdk.api.tzero.v1.payment_intent.beneficiary_connect import BeneficiaryServiceASGIApplication
+from t0_provider_sdk.api.tzero.v1.payment_intent.network_connect import PaymentIntentServiceClient
+from t0_provider_sdk.api.tzero.v1.payment_intent.pay_in_provider_connect import PayInProviderServiceASGIApplication
 from t0_provider_sdk.network.client import new_service_client
 from t0_provider_sdk.provider.handler import handler, new_asgi_app
 
 from provider.config import Config, load_config
+from provider.create_payment_intent import create_payment_intent  # noqa: F401
+from provider.get_payment_intent_quote import get_payment_intent_quote
 from provider.get_quote import get_quote
 from provider.handler.payment import ProviderServiceImplementation
+from provider.handler.payment_intent_beneficiary import BeneficiaryServiceImplementation
+from provider.handler.payment_intent_pay_in import PayInProviderServiceImplementation
+from provider.publish_payment_intent_quotes import publish_payment_intent_quotes
 from provider.publish_quotes import publish_quotes
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -64,15 +74,37 @@ def init_network_client(config: Config) -> NetworkServiceClient:
     )
 
 
-def create_provider_app(config: Config, network_client: NetworkServiceClient):
+def init_payment_intent_client(config: Config) -> PaymentIntentServiceClient:
+    """Create a payment intent service client with signing transport.
+
+    Go equivalent: initPaymentIntentClient()
+    """
+    return new_service_client(
+        config.provider_private_key,
+        PaymentIntentServiceClient,
+        base_url=config.tzero_endpoint,
+    )
+
+
+def create_provider_app(
+    config: Config,
+    network_client: NetworkServiceClient,
+    payment_intent_client: PaymentIntentServiceClient,
+):
     """Create the provider ASGI application.
 
     Go equivalent: startProviderServer()
     """
-    service = ProviderServiceImplementation(network_client)
+    provider_service = ProviderServiceImplementation(network_client)
+    pay_in_service = PayInProviderServiceImplementation(payment_intent_client)
+    beneficiary_service = BeneficiaryServiceImplementation()
     return new_asgi_app(
         config.network_public_key,
-        handler(ProviderServiceASGIApplication, service),
+        handler(ProviderServiceASGIApplication, provider_service),
+        # Phase 3A — Pay-In Provider role. Remove if you are only a beneficiary.
+        handler(PayInProviderServiceASGIApplication, pay_in_service),
+        # Phase 3B — Beneficiary Provider role. Remove if you are only a pay-in provider.
+        handler(BeneficiaryServiceASGIApplication, beneficiary_service),
     )
 
 
@@ -80,8 +112,9 @@ async def main() -> None:
     config = load_config()
 
     network_client = init_network_client(config)
+    payment_intent_client = init_payment_intent_client(config)
 
-    app = create_provider_app(config, network_client)
+    app = create_provider_app(config, network_client, payment_intent_client)
 
     # Step 1.1 is done. You successfully initialised starter template
     logger.info("Step 1.1: Provider server initialized on :%d", config.port)
@@ -100,6 +133,24 @@ async def main() -> None:
     # TODO: Step 1.4 Verify that quotes for target currency are successfully received
     quote_task = asyncio.create_task(get_quote(network_client))
 
+    # ──────────────────────────────────────────────────────────────
+    # Payment Intent Flow — Phase 3
+    #
+    # Implement the role that applies to you. See the README for details.
+    # ──────────────────────────────────────────────────────────────
+
+    # Phase 3A — Pay-In Provider role. Comment out if you are only a beneficiary.
+    # TODO: Step 3A.1 Replace with your own pay-in quote publishing logic
+    intent_publish_task = asyncio.create_task(
+        publish_payment_intent_quotes(payment_intent_client, shutdown_event),
+    )
+
+    # Phase 3B — Beneficiary Provider role. Comment out if you are only a pay-in provider.
+    # TODO: Step 3B.1 Check that indicative quotes are being returned
+    intent_quote_task = asyncio.create_task(get_payment_intent_quote(payment_intent_client))
+    # TODO: Step 3B.2 Create a payment intent for a real end-user when they want to pay
+    # await create_payment_intent(payment_intent_client)
+
     # Run ASGI server
     server_config = uvicorn.Config(app, host="0.0.0.0", port=config.port, log_level="info")
     server = uvicorn.Server(server_config)
@@ -114,6 +165,8 @@ async def main() -> None:
     shutdown_event.set()
     publish_task.cancel()
     quote_task.cancel()
+    intent_publish_task.cancel()
+    intent_quote_task.cancel()
 
 
 if __name__ == "__main__":

--- a/python/starter/src/t0_provider_starter/template/src/provider/publish_payment_intent_quotes.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/publish_payment_intent_quotes.py
@@ -1,0 +1,77 @@
+"""Payment intent quote publishing to the T-0 Network.
+
+Go equivalent: internal/publish_payment_intent_quotes.go → PublishPaymentIntentQuotes()
+
+Pay-In Provider role — Step 3A.1. Publishes sample pay-in quotes every 5 seconds.
+Replace the hardcoded values with quotes from your own pricing systems.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+
+from google.protobuf.timestamp_pb2 import Timestamp
+from t0_provider_sdk.api.tzero.v1.common.common_pb2 import Decimal
+from t0_provider_sdk.api.tzero.v1.common.payment_method_pb2 import PAYMENT_METHOD_TYPE_SEPA
+from t0_provider_sdk.api.tzero.v1.payment_intent.network_connect import PaymentIntentServiceClient
+from t0_provider_sdk.api.tzero.v1.payment_intent.network_pb2 import UpdateQuoteRequest
+
+logger = logging.getLogger(__name__)
+
+PUBLISH_INTERVAL_SECONDS = 5
+
+
+def _now_timestamp() -> Timestamp:
+    ts = Timestamp()
+    ts.GetCurrentTime()
+    return ts
+
+
+def _expiration_timestamp(seconds_from_now: int = 30) -> Timestamp:
+    ts = _now_timestamp()
+    ts.seconds += seconds_from_now
+    return ts
+
+
+async def publish_payment_intent_quotes(
+    payment_intent_client: PaymentIntentServiceClient,
+    shutdown_event: asyncio.Event,
+) -> None:
+    """Publish sample pay-in quotes on a regular interval.
+
+    NOTE: Every UpdateQuote request discards all previous payment intent quotes.
+    If you want to publish multiple quotes, combine them into a single request.
+    """
+    while not shutdown_event.is_set():
+        try:
+            await payment_intent_client.update_quote(
+                UpdateQuoteRequest(
+                    payment_intent_quotes=[
+                        UpdateQuoteRequest.Quote(
+                            currency="EUR",
+                            payment_method=PAYMENT_METHOD_TYPE_SEPA,
+                            expiration=_expiration_timestamp(30),
+                            timestamp=_now_timestamp(),
+                            bands=[
+                                UpdateQuoteRequest.Quote.Band(
+                                    client_quote_id=str(uuid.uuid4()),
+                                    max_amount=Decimal(unscaled=1000, exponent=0),  # max 1000 USD
+                                    # rate is always USD/XXX, so for EUR quote should be USD/EUR
+                                    rate=Decimal(unscaled=92, exponent=-2),  # rate 0.92
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            )
+        except Exception:
+            logger.exception("Error updating payment intent quote")
+            return
+
+        try:
+            await asyncio.wait_for(shutdown_event.wait(), timeout=PUBLISH_INTERVAL_SECONDS)
+            return  # shutdown requested
+        except TimeoutError:
+            pass  # interval elapsed, publish again


### PR DESCRIPTION
## Summary

Extends all four starter templates (Go, Node, Python, Java) with working examples for the **payment intent flow** — an asynchronous pay-in flow where an end-user pays a pay-in provider in fiat and a beneficiary provider receives settlement on the crypto side. Until now only proto definitions and generated code existed for this flow; integrators had no reference to copy.

Each starter now demonstrates **both provider roles** with clear, separable file naming so an integrator who only plays one role can delete the other half:

| Pay-In Provider role (Phase 3A) | Beneficiary Provider role (Phase 3B) |
|---|---|
| `payment_intent_pay_in.*` — `GetPaymentDetails` handler | `payment_intent_beneficiary.*` — `PaymentIntentUpdate` handler |
| `publish_payment_intent_quotes.*` — periodic `PaymentIntentService.UpdateQuote` | `get_payment_intent_quote.*` — indicative `PaymentIntentService.GetQuote` |
| `confirm_funds_received.*` — `PaymentIntentService.ConfirmFundsReceived` | `create_payment_intent.*` — `PaymentIntentService.CreatePaymentIntent` |

Python ships both async and sync variants for the handlers, matching the existing `payment.py` / `payment_sync.py` pattern.

The main entry point of each starter builds a second signing client for `PaymentIntentService`, registers both new handlers alongside the existing payment handler, and schedules the new publish/fetch tasks, with "remove if not your role" comments. READMEs gain a Phase 3 section describing the flow and the 3A/3B role branching, and the project-structure listings are updated.

**Node SDK prerequisite:** added namespace re-exports for `PaymentIntentService`, `PayInProviderService`, and `BeneficiaryService` in `node/sdk/src/index.ts` so starter code can reach them via `@t-0/provider-sdk`.

## Test plan

- [x] `cd go && go build ./... && go vet ./... && go test ./...`
- [x] Go starter template compiles (verified with temporary local replace directive)
- [x] `cd node/sdk && npm run build && npm test`
- [x] `cd java && ./gradlew build -x distTar -x distZip`
- [x] `cd python && uv run ruff check .`
- [ ] End-to-end: generate a project via each starter CLI, run against the sandbox, confirm both roles' log lines appear and the two new handlers are invoked when a payment intent is fired at the service
- [ ] Cross-language README parity — each SDK's Phase 3 section should describe the same 3A/3B steps

Scope note: the `payment_intent/provider/` hosted-URL variant and `payment_intent/recipient/` variant are intentionally out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)