### PR TITLE
fix: tighten Router.service typing; rename approvePaymentQuotes handler

### DIFF
--- a/node/sdk/src/service/service.ts
+++ b/node/sdk/src/service/service.ts
@@ -55,7 +55,10 @@ const createSignatureVerification: (networkPublicKey: Buffer) => Interceptor = (
 };
 
 interface Router {
-  service: <T extends DescService>(service: T, implementation: Partial<ServiceImpl<T>>) => void;
+  service: <T extends DescService, I extends ServiceImpl<T>>(
+    service: T,
+    implementation: I,
+  ) => void;
 }
 
 export const createService = (

--- a/node/starter/template/src/service.ts
+++ b/node/starter/template/src/service.ts
@@ -69,7 +69,7 @@ const CreateProviderService = (networkClient: Client<typeof NetworkService>) => 
             return {} as AppendLedgerEntriesResponse
         },
 
-        async approvePaymentQuote(req: ApprovePaymentQuoteRequest, _: HandlerContext) {
+        async approvePaymentQuotes(req: ApprovePaymentQuoteRequest, _: HandlerContext) {
             // TODO: when the payment goes through the Manual AML Check on the pay-out provider side, the provider submitted the payment will have a last look to approve final quote
             // The request includes payOutFix — the fixed charge in USD for this payout.
             // Consider it alongside payOutRate and payOutAmount when deciding to accept.


### PR DESCRIPTION
## Summary

- Rename starter handler `approvePaymentQuote` → `approvePaymentQuotes` so it matches the proto RPC `ApprovePaymentQuotes` (`proto/tzero/v1/payment/provider.proto:56`). Without this rename the network's call lands on no handler and Connect responds `Unimplemented`.
- Tighten `Router.service` in `node/sdk/src/service/service.ts` from `Partial<ServiceImpl<T>>` to a generic constraint:
  ```ts
  service: <T extends DescService, I extends ServiceImpl<T>>(
    service: T,
    implementation: I,
  ) => void;
  ```
  This requires every proto-declared method on the implementation (catches the bug above at compile time) while still allowing extra helper/state properties — including on fresh object literals — because TS infers `I` from the impl shape.

## Why the build didn't catch this before

`Partial<>` made every RPC optional, so a missing `approvePaymentQuotes` was silently fine. The misnamed `approvePaymentQuote` then slipped through structural typing because the impl is built inside a factory (`CreateProviderService(networkClient)`) and TS only runs excess-property checks on fresh literals passed directly.

## Test plan

- [x] `cd node/sdk && npm run build` — passes
- [x] `cd node/sdk && npm test` — 23/23 pass
- [x] `cd node/starter && npm run build` — passes
- [x] Verified bug-catch: with the local SDK linked into the template, reverting the singular name made `tsc` fail with `Property 'approvePaymentQuotes' is missing in type ... but required in type 'ServiceImpl<...>'` at `index.ts:55`. Restoring the plural name removed the error.
- [x] Verified extras tolerated: adding a non-RPC `extraHelper: () => "hello"` to the impl object produced zero new errors.
- [x] Cross-language consistency: Go (`go/starter/.../payment.go:74`) and Python tests already use `ApprovePaymentQuotes` / `approve_payment_quotes`. Only the Node starter was off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)