### PR TITLE
ci(node): type-check starter template against locally built SDK

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,32 @@ jobs:
         working-directory: node/sdk
         run: npm test
 
+      # Type-check the starter template against the freshly built SDK.
+      # The template ships to providers as a scaffolded project; without
+      # this guard, schema/API drift between the SDK and the template is
+      # only caught when a provider runs `npm run build` for the first
+      # time. We pack the local SDK and overlay it on top of the
+      # template's normal `npm install` (which fetches the published SDK
+      # from the registry) so we type-check against unreleased changes too.
+      - name: Pack SDK for template type-check
+        working-directory: node/sdk
+        run: npm pack
+
+      - name: Install starter template dependencies
+        # `npm install` (not `npm ci`) because the template's package-lock.json
+        # is not strict-locked to the latest SDK — providers regenerate it on
+        # first install. We just need a working install for type checking.
+        working-directory: node/starter/template
+        run: npm install --no-audit --no-fund
+
+      - name: Overlay local SDK build into template
+        working-directory: node/starter/template
+        run: npm install --no-save --no-audit --no-fund ../../sdk/t-0-provider-sdk-*.tgz
+
+      - name: Type-check starter template against local SDK
+        working-directory: node/starter/template
+        run: npx tsc --noEmit -p tsconfig.typecheck.json
+
   java:
     name: Java
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/node/starter/template/tsconfig.typecheck.json
+++ b/node/starter/template/tsconfig.typecheck.json
@@ -1,0 +1,13 @@
+{
+  // CI-only typecheck config used by .github/workflows/ci.yaml to validate
+  // this template against the local SDK before publishing. The shipped
+  // tsconfig.json uses module=commonjs (matching providers' typical Node
+  // runtime deployments) which conflicts with moduleResolution=bundler
+  // (TS5095). This override flips module to esnext so tsc can run; it is
+  // not used at build/runtime by providers and is safe to ignore or delete
+  // in a scaffolded project.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext"
+  }
+}


### PR DESCRIPTION
## Summary

Add a CI guard that catches schema/API drift between the SDK and the starter template before it reaches a scaffolded provider project — the kind of gap that produced the recent `.Result` casing regression (#88) and the `approvePaymentQuotes` rename (#85).

After building `node/sdk` and running its tests, the Node job now:

1. `npm pack`s the freshly built SDK.
2. Runs `npm install` in `node/starter/template` (template's lockfile drifts naturally between SDK releases — providers regenerate it on first install — so we don't `npm ci`).
3. Overlays the local SDK with `npm install --no-save ../../sdk/t-0-provider-sdk-*.tgz` so the type-check sees unreleased schema changes too.
4. Runs `tsc --noEmit -p tsconfig.typecheck.json`.

## Why a separate `tsconfig.typecheck.json`

The shipped `node/starter/template/tsconfig.json` uses `module: commonjs` to match providers' typical Node deployments. Combined with `moduleResolution: bundler` this triggers TS5095 (`Option 'bundler' can only be used when 'module' is set to 'preserve' or to 'es2015' or later`), so plain `tsc` errors at config parse before it can validate the source.

Rather than change the shipped config (we've had npm publish friction with `module` flag changes in the past), the new `tsconfig.typecheck.json` simply extends `tsconfig.json` and overrides `module` to `esnext`. It is CI-only; if it ends up shipped to providers via the `template/` directory in the published `provider-starter-ts` package, it does not affect their build (`npm run build` still uses `tsconfig.json`) and is safe to ignore or delete in the scaffolded project.

## Test plan

Verified locally end-to-end against current master (`v1.1.15`, including the auto-registered `SystemService`):

- [x] `cd node/sdk && npm pack` produces `t-0-provider-sdk-1.1.15.tgz`.
- [x] `cd node/starter/template && npm install --no-audit --no-fund` succeeds (~2 s, 33 packages).
- [x] `npm install --no-save --no-audit --no-fund ../../sdk/t-0-provider-sdk-*.tgz` overlays the local SDK without touching `package.json`/`package-lock.json`.
- [x] `npx tsc --noEmit -p tsconfig.typecheck.json` exits **0** on master.
- [x] **Regression catch.** Reverting any one `.result` to `.Result` in the template makes `tsc` exit **2** with `error TS2551: Property 'Result' does not exist on type 'GetQuoteResponse'. Did you mean 'result'?` Restoring brings exit code back to 0. (Restored before commit.)

## What this does not yet cover

- The CLI scaffolding flow itself (placeholder substitution, `provider-init` end-to-end). Worth a follow-up that `node bin/cli.js test-project --no-prompts` and runs `tsc` on the resulting directory — would also exercise the package layout providers actually receive.
- Type-checking the template against the **published** SDK on every PR (we only check against the local build). Useful only if a published SDK can change outside the release flow (e.g., via `npm dist-tag`), which is not the case today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)