### PR TITLE
docs(java): document dual-framing signature verification rationale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Go requires additional module tags: `go/vX.Y.Z`, `go/starter/vX.Y.Z`, `go/starte
 
 - **release.yaml** — Triggered manually. Bumps version, creates tags + GitHub Release.
 - **publish.yaml** — Triggered by tag push. Publishes to npm, PyPI, Maven Central, Go Module Proxy.
-- **proto_sync.yaml** — Syncs proto files from backend.
+- **proto_sync.yaml** — Syncs proto files from upstream proto source.
 - **generate-clients.yaml** — Regenerates language-specific code from protos.
 
 ## Build & Test (all languages)
@@ -59,6 +59,12 @@ headers = { X-Public-Key: "0x...", X-Signature: "0x...", X-Signature-Timestamp: 
 - Public keys: uncompressed secp256k1 (65 bytes, 0x04 prefix)
 - Signatures: 64 or 65 bytes (r + s + optional recovery id)
 - Hash: Keccak-256 (NOT NIST SHA-3)
+
+### body_bytes framing — depends on signer position
+
+`body_bytes` is whichever bytes the signer covers at its own layer. For SDK clients in this repo and Connect-protocol callers in general, that is **unframed protobuf** (the Java SDK's `NetworkClient` signs above the gRPC framer; Go / Node / Python use Connect protocol, where no frame exists). The T-0 Network signs unframed bytes when calling a provider via Connect protocol, and signs the **gRPC-framed body** (5-byte prefix + protobuf) when calling via gRPC protocol — in that case the signer sits below the framer.
+
+Consequently the Java SDK's `SignatureVerificationInterceptor` accepts both framings. **This dual-path is required, not defensive** — see [`docs/java/SIGNATURE_VERIFICATION.md`](docs/java/SIGNATURE_VERIFICATION.md) before touching it.
 
 ## Releasing
 

--- a/docs/java/ISSUES_AND_LESSONS.md
+++ b/docs/java/ISSUES_AND_LESSONS.md
@@ -2,6 +2,19 @@
 
 Historical issues encountered during development, extracted from git history. Organized chronologically (newest first).
 
+## Near-Miss: Removing dual-framing signature verification (issue #89)
+
+**Problem:** A cross-language code review flagged the dual-path verification in `SignatureVerificationInterceptor.verifySignature` (tries unframed first, then gRPC-framed) as architecturally fragile and possibly dead code, since all four SDK clients shipped in this repo sign unframed bytes. Issue #89 proposed investigation before removal.
+
+**Root cause of confusion:** The survey covered only the SDK clients in this repo. It missed that the T-0 Network is itself a signing party calling providers, and that the network's signed payload depends on the transport configured for the provider — for Connect protocol it signs unframed bytes, for gRPC protocol it signs the gRPC-framed body (5-byte frame prefix + protobuf). The framed verification path is therefore alive in production whenever the network is configured to call a provider via gRPC protocol.
+
+**Resolution:** No code change. The dual-path is correct and required. Added:
+- Strengthened class-level and method-level Javadoc on `SignatureVerificationInterceptor` calling out that both paths are load-bearing and which callers exercise each.
+- New doc [`SIGNATURE_VERIFICATION.md`](SIGNATURE_VERIFICATION.md) with the precise signing-payload definition per network transport.
+- Cross-references from root `CLAUDE.md` and `java/CLAUDE.md`.
+
+**Lesson:** When auditing a verification path that "looks dead", the survey must include every signing party that can talk to the verifier — including the network itself — not just same-repo SDK clients. A path exercised by only one class of caller still cannot be removed if that class of caller is real production traffic.
+
 ## JitPack Dependency Coordinates (v1.0.31–1.0.33)
 
 **Problem:** Template used wrong JitPack coordinates `com.github.t-0.provider-sdk-java:sdk` — wrong GitHub org separator (`.` vs `-`), wrong repo name, and included a nonexistent submodule path.

--- a/docs/java/SIGNATURE_VERIFICATION.md
+++ b/docs/java/SIGNATURE_VERIFICATION.md
@@ -1,0 +1,92 @@
+# Signature Verification — Dual-Path Design
+
+## TL;DR
+
+`SignatureVerificationInterceptor.verifySignature` accepts a request if the signature validates against **either** of two payload framings:
+
+1. **Unframed** — raw protobuf bytes: `Keccak256(messageBytes || ts_le_u64)`
+2. **gRPC-framed** — 5-byte gRPC frame prefix + protobuf bytes: `Keccak256(frame_prefix || messageBytes || ts_le_u64)`
+
+**This is not defensive code. Both paths are exercised by real callers in production.** Do not remove either path.
+
+## Why two paths?
+
+The signed payload depends on **where the signing interceptor sits in the stack**, not on which protocol is in use. Two equally valid wirings exist:
+
+- **Signer above the gRPC framer.** The interceptor signs the protobuf message bytes; the gRPC framer then prepends the 5-byte frame on the wire. The signed payload is **unframed** protobuf. This is how the Java SDK's `NetworkClient` is wired: it pulls bytes from the request marshaller, signs those bytes, and forwards them so the gRPC layer cannot re-serialize and produce different bytes.
+- **Signer below the gRPC framer.** The interceptor sits at the HTTP transport layer and sees a body onto which the framer has already prepended the 5-byte frame. The signed payload therefore covers **the frame**.
+
+Both wirings produce a deterministic, reproducible signed payload. Neither is wrong — they cover different bytes because the interceptor sits at different layers.
+
+## What the T-0 Network does
+
+The T-0 Network is a signing party that calls providers. The bytes the network signs depend on which transport the network has been configured to use for a given provider:
+
+| Network → provider transport | Signed payload |
+|---|---|
+| Connect protocol with proto binary | unframed protobuf bytes |
+| Connect protocol with proto JSON | unframed JSON bytes |
+| **gRPC protocol** | **gRPC-framed body: 5-byte frame prefix (1 byte compressed flag = 0, then 4 bytes big-endian length) followed by the protobuf message bytes** |
+
+The signature itself is constructed identically in every case:
+
+```
+ts_le_u64 = uint64(timestamp_ms) encoded little-endian, 8 bytes
+digest    = Keccak256(payload_bytes || ts_le_u64)
+signature = secp256k1_sign(network_private_key, digest)
+```
+
+with `payload_bytes` being whichever of the framings above corresponds to the configured transport. Headers sent on the request:
+
+- `X-Public-Key` — uncompressed secp256k1 public key, hex-encoded with `0x` prefix (65 bytes raw, 0x04 prefix on the key itself)
+- `X-Signature` — signature, hex-encoded with `0x` prefix (64 or 65 bytes raw)
+- `X-Signature-Timestamp` — millisecond Unix timestamp as a decimal string
+
+A Java provider therefore receives:
+- **gRPC-framed** signatures whenever the network is configured to call it via gRPC protocol.
+- **Unframed** signatures whenever the network is configured to call it via Connect protocol, **and** from the Java SDK's own `NetworkClient` (which signs above the framer).
+
+Both must validate. Hence the dual-path.
+
+## What the verifier does
+
+```java
+// Path 1: unframed (signer was above the framer, or no framing exists).
+byte[] digestRaw = Keccak256.hash(bodyBytes, timestampBytes);
+if (SignatureVerifier.verify(publicKey, digestRaw, signature)) return true;
+
+// Path 2: gRPC-framed (signer was below the framer).
+byte[] framedBytes = reconstructGrpcFrame(bodyBytes);
+byte[] digestFramed = Keccak256.hash(framedBytes, timestampBytes);
+if (SignatureVerifier.verify(publicKey, digestFramed, signature)) return true;
+
+return false;
+```
+
+`bodyBytes` is the raw protobuf message bytes as delivered by `ServerInterceptors.useInputStreamMessages` — the gRPC server has already stripped the 5-byte frame before the interceptor sees the bytes. Reconstruction in path 2 is straightforward: 1 byte compressed flag (0) + 4 bytes big-endian length of `bodyBytes`, prepended.
+
+The network's verification logic on its own ingress mirrors this dual-path with the symmetric convention: it tries the on-wire body first, and for gRPC requests retries with the 5-byte frame stripped. The two systems together accept any caller whose signing wiring is internally consistent (signs and sends the exact same bytes at the same layer), regardless of whether that layer is above or below the framer.
+
+## CRITICAL: do not remove either path
+
+Removing path 1 silently breaks every caller whose signing wiring is above the framer — including the Java SDK's own `NetworkClient`, and the network when calling Java providers configured for Connect protocol. Removing path 2 silently breaks every caller whose signing wiring is below the framer — including the network when calling Java providers configured for gRPC protocol.
+
+In both cases the failure surfaces only as `UNAUTHENTICATED` responses for one class of caller, not the other — the kind of stealth breakage that is hard to attribute and easy to misdiagnose.
+
+GitHub issue [#89](https://github.com/t-0-network/provider-sdk/issues/89) raised concern that the framed path looked like dead code because the SDK clients shipped in this repo all sign unframed. The audit was incomplete — it considered only same-repo SDK clients and missed the network's gRPC-protocol path, which signs framed bodies. Both framings are required.
+
+## Conditions under which simplification would be safe
+
+A single canonical framing could be enforced only if **all** signing parties that talk to a Java provider can be confirmed to sign at the same layer. That confirmation must include:
+
+- All four SDK clients in this repo (currently all sign unframed).
+- The network for every transport configuration it can be set to use against the provider.
+- Any third-party client built directly on a gRPC framework, where the integrator chose where to wire signing.
+
+Until that confirmation is gathered for a sustained window with metrics, the dual-path stays.
+
+## References
+
+- `java/sdk/src/main/java/network/t0/sdk/provider/SignatureVerificationInterceptor.java` — `verifySignature`, `reconstructGrpcFrame`
+- `java/sdk/src/main/java/network/t0/sdk/network/NetworkClient.java` — `SigningClientInterceptor`, where the Java SDK signs above the framer
+- GitHub issue (closed as no-op after investigation): https://github.com/t-0-network/provider-sdk/issues/89

--- a/java/CLAUDE.md
+++ b/java/CLAUDE.md
@@ -16,6 +16,17 @@ byte[] rawBytes = getOriginalRequestBytes();
 verifySignature(rawBytes, signature);
 ```
 
+## Signature Verification — Dual Framing (DO NOT REMOVE)
+
+`SignatureVerificationInterceptor.verifySignature` accepts signatures over **either** unframed protobuf **or** the 5-byte-gRPC-framed body. Both paths are load-bearing in production:
+
+- **Unframed path** — Java SDK's own `NetworkClient` (signs above the gRPC framer), Connect-protocol callers in Go / Node / Python (no frame exists), and the T-0 Network when configured to call this provider via Connect protocol.
+- **gRPC-framed path** — T-0 Network when configured to call this provider via gRPC protocol. The signer sits below the gRPC framer, so the signed payload covers the 5-byte frame prefix (1 byte compressed flag + 4 bytes big-endian length) followed by the protobuf message bytes.
+
+Removing either path silently breaks one class of caller with `UNAUTHENTICATED` errors.
+
+GitHub issue #89 raised concern that the framed path looked like dead code — investigation confirmed it is alive and required because the network's gRPC-protocol path signs framed bodies. See [`docs/java/SIGNATURE_VERIFICATION.md`](../../docs/java/SIGNATURE_VERIFICATION.md) for the precise signing-payload definitions per transport and conditions under which simplification would be safe.
+
 ---
 
 ## Build Commands
@@ -102,6 +113,7 @@ See [`docs/java/ISSUES_AND_LESSONS.md`](../../docs/java/ISSUES_AND_LESSONS.md) f
 ## Documentation
 
 Docs live in the top-level [`docs/java/`](../../docs/java/) directory:
+- [`SIGNATURE_VERIFICATION.md`](../../docs/java/SIGNATURE_VERIFICATION.md) — dual-path verification rationale (CRITICAL — read before touching `SignatureVerificationInterceptor`)
 - [`GITHUB_SETUP.md`](../../docs/java/GITHUB_SETUP.md) — CI/CD, secrets, publishing setup
 - [`STARTER_ARCHITECTURE.md`](../../docs/java/STARTER_ARCHITECTURE.md) — how the init system works
 - [`PROTO_SCHEMA_MANAGEMENT.md`](../../docs/java/PROTO_SCHEMA_MANAGEMENT.md) — protobuf code generation

--- a/java/sdk/src/main/java/network/t0/sdk/provider/SignatureVerificationInterceptor.java
+++ b/java/sdk/src/main/java/network/t0/sdk/provider/SignatureVerificationInterceptor.java
@@ -28,7 +28,10 @@ import java.time.Clock;
  *   <li>Validate timestamp is within the allowed window (60 seconds)</li>
  *   <li>Read the raw request body from InputStream</li>
  *   <li>Compute: digest = Keccak256(body + timestampBytes)</li>
- *   <li>Verify the signature against the expected network public key</li>
+ *   <li>Verify the signature against the expected network public key, accepting either
+ *       unframed (raw protobuf) or gRPC-framed (5-byte prefix + protobuf) framings —
+ *       see {@link #verifySignature} for the rationale and {@code docs/java/SIGNATURE_VERIFICATION.md}
+ *       for the precise signing-payload definitions per caller and transport.</li>
  * </ol>
  *
  * <p>Error handling:
@@ -168,46 +171,67 @@ public final class SignatureVerificationInterceptor implements ServerInterceptor
     /**
      * Verifies the signature against the message body.
      *
-     * <p>This method supports both Connect protocol (raw protobuf) and gRPC protocol (with framing).
-     * The client signs the full HTTP body, which differs based on the protocol:
+     * <p><b>DUAL-PATH IS LOAD-BEARING — DO NOT REMOVE EITHER PATH.</b>
+     *
+     * <p>Both verification paths below are exercised by real production traffic. The asymmetry
+     * exists because different signers sit at different layers relative to the gRPC framer:
+     *
      * <ul>
-     *   <li>Connect protocol: HTTP body = raw protobuf bytes</li>
-     *   <li>gRPC protocol: HTTP body = 5-byte frame prefix + raw protobuf bytes</li>
+     *   <li><b>Path 1 — unframed (raw protobuf):</b> Used by callers whose signing interceptor
+     *       sits <i>above</i> the gRPC framer. This includes the Java SDK's own
+     *       {@code NetworkClient} (signs bytes pulled from the marshaller stream before framing)
+     *       and any caller whose transport is Connect protocol (where no gRPC frame exists at
+     *       all). The T-0 Network signs unframed bytes when configured to call this provider via
+     *       Connect protocol.</li>
+     *   <li><b>Path 2 — gRPC-framed:</b> Used when the signer sits <i>below</i> the gRPC framer
+     *       and signs the on-wire body. The signed payload then includes the 5-byte gRPC frame
+     *       prefix (1 byte compressed flag + 4 bytes big-endian length) followed by the protobuf
+     *       message bytes. The T-0 Network signs framed bodies when configured to call this
+     *       provider via gRPC protocol.</li>
      * </ul>
      *
-     * <p>Since the Java server receives only the protobuf bytes (gRPC strips the frame),
-     * we try verification both ways:
-     * <ol>
-     *   <li>First, verify against raw protobuf bytes (Connect protocol)</li>
-     *   <li>If that fails, reconstruct the gRPC frame and verify against framed bytes</li>
-     * </ol>
+     * <p>Removing path 2 silently breaks all traffic from the T-0 Network whenever it is
+     * configured to call this provider via gRPC protocol. Removing path 1 silently breaks the
+     * Java SDK's own {@code NetworkClient}, plus T-0 Network traffic configured to use Connect
+     * protocol. Both failures surface only as {@code UNAUTHENTICATED} responses for one class of
+     * caller but not the other — exactly the kind of stealth breakage that looks like an
+     * unrelated bug.
+     *
+     * <p>For the full architectural rationale, the network's signing behavior in detail, and
+     * conditions under which simplification would be safe, see
+     * {@code docs/java/SIGNATURE_VERIFICATION.md}.
      *
      * @param publicKey the public key to verify against
-     * @param bodyBytes the raw protobuf message bytes (without gRPC frame)
+     * @param bodyBytes the raw protobuf message bytes (without gRPC frame, as delivered by
+     *                  {@link ServerInterceptors#useInputStreamMessages})
      * @param timestampMs the request timestamp in milliseconds
      * @param signature the signature to verify
-     * @return true if signature is valid for either format
+     * @return true if signature is valid for either framing
      */
     private boolean verifySignature(byte[] publicKey, byte[] bodyBytes, long timestampMs, byte[] signature) {
         byte[] timestampBytes = Headers.encodeTimestamp(timestampMs);
 
-        // Try 1: Verify against raw protobuf bytes (Connect protocol - no framing)
+        // Path 1: unframed (raw protobuf). Matches the Java SDK's NetworkClient, Connect-
+        // protocol callers (no frame exists), and the T-0 Network when configured to call
+        // this provider via Connect protocol.
         byte[] digestRaw = Keccak256.hash(bodyBytes, timestampBytes);
         if (SignatureVerifier.verify(publicKey, digestRaw, signature)) {
-            log.debug("Signature verified using Connect protocol (raw protobuf)");
+            log.debug("Signature verified against unframed body");
             return true;
         }
 
-        // Try 2: Verify against gRPC-framed bytes (5-byte prefix + protobuf)
-        // gRPC frame format: 1 byte compressed flag (0) + 4 bytes length (big-endian)
+        // Path 2: gRPC-framed (5-byte prefix + protobuf). Matches the T-0 Network when
+        // configured to call this provider via gRPC protocol. The signer sits below the
+        // gRPC framer, so the signed payload includes the on-wire frame.
+        // gRPC frame format: 1 byte compressed flag (0) + 4 bytes length (big-endian).
         byte[] framedBytes = reconstructGrpcFrame(bodyBytes);
         byte[] digestFramed = Keccak256.hash(framedBytes, timestampBytes);
         if (SignatureVerifier.verify(publicKey, digestFramed, signature)) {
-            log.debug("Signature verified using gRPC protocol (with frame prefix)");
+            log.debug("Signature verified against gRPC-framed body");
             return true;
         }
 
-        log.debug("Signature verification failed for both Connect and gRPC protocols");
+        log.debug("Signature verification failed for both unframed and gRPC-framed payloads");
         return false;
     }
 


### PR DESCRIPTION
## Summary

- Dual-path signature verification in `SignatureVerificationInterceptor` (tries unframed protobuf first, then 5-byte gRPC-framed) was flagged as possible dead code in #89. Investigation showed it is alive and required: the T-0 Network signs framed bodies when configured to call a provider via gRPC protocol, so removing the framed path would silently break that traffic.
- Doc-only change. No logic or API edits — only Javadoc, inline comments, and three DEBUG log strings clarified.
- Adds [`docs/java/SIGNATURE_VERIFICATION.md`](docs/java/SIGNATURE_VERIFICATION.md) with the precise signing-payload definition per caller and transport, "DO NOT REMOVE" callouts on `verifySignature`, cross-references from root and `java/` `CLAUDE.md`, and a near-miss entry in `ISSUES_AND_LESSONS.md` to prevent the same audit mistake.

Closes #89

## Backward compatibility

Zero risk:
- `verifySignature` and `reconstructGrpcFrame` byte-identical (verified via diff).
- Public/protected API surface unchanged.
- Wire protocol unchanged.
- Cross-language test vectors untouched.
- Build + `:sdk:test` pass.

Three DEBUG-level log strings were rephrased for accuracy (`"Connect protocol (raw protobuf)"` → `"unframed body"`, etc.). Not part of any API contract; no internal tests assert on these strings.

## Test plan

- [x] `./gradlew :sdk:compileJava` passes
- [x] `./gradlew :sdk:test` passes
- [x] No remaining references to private repo paths or internal config names (`backend/pkg/...`, `SerializationType`, `connect.WithGRPC()`) — verified by grep across all edited files
- [ ] Reviewer confirms the precise per-transport signing-payload table in `SIGNATURE_VERIFICATION.md` matches operator expectations