### PR TITLE
chore(python): upgrade to connectrpc 0.10.0 and pin all buf plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ Run tests per language:
 
 | PyPI Package | Import | Purpose | Notes |
 |---|---|---|---|
-| `connect-python` | `connectrpc` | ConnectRPC runtime | Do NOT use the `connectrpc` PyPI package (different, unmaintained) |
+| `connectrpc` | `connectrpc` | ConnectRPC runtime | PyPI distribution renamed from `connect-python` at v0.10.0; pin `>=0.10.0` |
 | `protobuf` | `google.protobuf` | Message serialization | >= 5.28 required |
 | `coincurve` | `coincurve` | secp256k1 ECDSA | Signing, verification, key derivation |
 | `pycryptodome` | `Crypto.Hash.keccak` | Keccak256 hash | Do NOT use `pysha3` (incompatible with Python 3.13) or `hashlib.sha3_256` (different padding) |

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -39,21 +39,19 @@ managed:
       value: T0.ProviderSdk.Api.Buf.Validate
 
 plugins:
-  # TODO: Pin plugin versions for reproducible generation (append :vX.Y.Z to remote URLs)
-  # Go deps: protobuf-go v1.36.11, connect v1.19.1
-  # Node deps: @bufbuild/protobuf ^2.10.0
-  # Python deps: protobuf >=5.28, connect-python >=0.8
+  # Plugin versions are pinned. When upgrading a runtime SDK, bump the matching
+  # plugin pin here in the same PR and run `buf generate`.
 
   # --- Go ---
-  - remote: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go:v1.36.11
     out: go/api
     opt: paths=source_relative
-  - remote: buf.build/connectrpc/go
+  - remote: buf.build/connectrpc/go:v1.19.1
     out: go/api
     opt: paths=source_relative
 
   # --- Node (TypeScript) ---
-  - remote: buf.build/bufbuild/es
+  - remote: buf.build/bufbuild/es:v2.12.0
     out: node/sdk/src/common/gen
     include_imports: true
     opt:
@@ -61,17 +59,17 @@ plugins:
       - import_extension=js
 
   # --- Python ---
-  - remote: buf.build/protocolbuffers/python
+  - remote: buf.build/protocolbuffers/python:v34.1
     out: python/sdk/src/t0_provider_sdk/api
-  - remote: buf.build/protocolbuffers/pyi
+  - remote: buf.build/protocolbuffers/pyi:v34.1
     out: python/sdk/src/t0_provider_sdk/api
-  - remote: buf.build/connectrpc/python
+  - remote: buf.build/connectrpc/python:v0.10.0
     out: python/sdk/src/t0_provider_sdk/api
 
   # --- C# ---
-  - remote: buf.build/protocolbuffers/csharp
+  - remote: buf.build/protocolbuffers/csharp:v34.0
     out: csharp/sdk/T0.ProviderSdk/Api
     opt: base_namespace=T0.ProviderSdk.Api
-  - remote: buf.build/grpc/csharp
+  - remote: buf.build/grpc/csharp:v1.78.0
     out: csharp/sdk/T0.ProviderSdk/Api
     opt: base_namespace=T0.ProviderSdk.Api

--- a/docs/SYSTEM_SERVICE.md
+++ b/docs/SYSTEM_SERVICE.md
@@ -104,8 +104,6 @@ Implementations live next to the wrapper:
 
 ### Per-language gotchas
 
-**Python — manual patch on generated `system_connect.py`.** The current connect-python plugin emits `from connectrpc.codec import Codec` and a `codecs=` kwarg, both of which break against the installed `connect-python==0.9.0` runtime. The committed [`python/sdk/src/t0_provider_sdk/api/tzero/v1/system/system_connect.py`](../python/sdk/src/t0_provider_sdk/api/tzero/v1/system/system_connect.py) has those lines manually removed. **If you re-run `buf generate`, re-apply the patch** (or pin the buf plugin version per the TODO in [`buf.gen.yaml`](../buf.gen.yaml) line ~42). The same regression affects every other `*_connect.py`; today the workaround is to revert their regenerations after every `buf generate`.
-
 **Java — `services.isEmpty()` validation is preserved.** `Builder.build()` rejects construction when no customer service was added via `withService(...)`. SystemService is appended **inside** `buildGrpcServer()`, never into `Builder.services`, so the check still catches "you forgot to add ProviderService".
 
 **Java — runtime version is a classpath resource, not a constant.** `META-INF/sdk-version.properties` ships in the jar; `SystemServiceImpl.loadSdkVersion()` reads it via `getResourceAsStream`. This works under jar shading, but consumers who repackage with relocation rules need to keep `META-INF/` intact.
@@ -139,4 +137,4 @@ Examples that do **not** fit and should be separate services:
 
 ### Known gaps
 
-- Buf plugin versions in [`buf.gen.yaml`](../buf.gen.yaml) are unpinned — TODO at line ~42. Pinning them (or upgrading `connect-python` to a release whose plugin output matches the runtime API) would eliminate the manual codec patch on `system_connect.py` noted above. Tracked separately.
+- No Python/Node/Java Health-specific tests yet (see "Tests covering Health" above).

--- a/docs/python/ARCHITECTURE.md
+++ b/docs/python/ARCHITECTURE.md
@@ -287,8 +287,8 @@ ConnectRPC was chosen over gRPC for its HTTP/1.1 compatibility, simpler deployme
 
 | Concern | Library | PyPI Name | Import | Rationale |
 |---------|---------|-----------|--------|-----------|
-| RPC Framework | connect-python | `connect-python>=0.8` | `connectrpc` | Official ConnectRPC Python runtime |
-| HTTP Client | pyqwest | *(transitive)* | `pyqwest` | Rust-backed HTTP client; transitive dependency of connect-python |
+| RPC Framework | connectrpc | `connectrpc>=0.10.0` | `connectrpc` | Official ConnectRPC Python runtime (renamed from `connect-python` at v0.10.0) |
+| HTTP Client | pyqwest | *(transitive)* | `pyqwest` | Rust-backed HTTP client; transitive dependency of connectrpc |
 | Protobuf | protobuf | `protobuf>=5.28` | `google.protobuf` | Standard Protocol Buffers runtime |
 | ECDSA Crypto | coincurve | `coincurve>=21.0` | `coincurve` | Python bindings for libsecp256k1 |
 | Keccak Hash | pycryptodome | `pycryptodome>=3.23` | `Crypto.Hash.keccak` | Legacy Keccak-256 implementation |
@@ -301,7 +301,7 @@ ConnectRPC was chosen over gRPC for its HTTP/1.1 compatibility, simpler deployme
 |----------|--------|
 | `pysha3` | Incompatible with Python 3.13 |
 | `hashlib.sha3_256()` | Implements NIST SHA-3, not legacy Keccak-256 (different padding) |
-| `connectrpc` on PyPI | Different package (v0.0.1 by Gaudiy), not the official ConnectRPC runtime |
+| Pre-0.10 `connectrpc` on PyPI (v0.0.1 by Gaudiy) | Squatted package, not the official runtime; pin `>=0.10.0` to skip it |
 | Subclassing `pyqwest.Client` | Rust-backed FFI object -- subclassing is fragile and undefined |
 
 ### 3.2 Package Architecture

--- a/docs/python/PITFALLS.md
+++ b/docs/python/PITFALLS.md
@@ -24,14 +24,14 @@ keccak.new(digest_bits=256, data=data).digest()
 
 ---
 
-## 2. `connectrpc` PyPI Package Trap
+## 2. `connectrpc` PyPI Package — Historical Naming
 
-| Package | PyPI name | Version | Status |
-|---------|-----------|---------|--------|
-| ConnectRPC official | `connect-python` | 0.8.x | **CORRECT** — imports as `connectrpc` |
-| Gaudiy's package | `connectrpc` | 0.0.1 | **WRONG** — different, unmaintained package |
+| Version range | PyPI name | Notes |
+|---|---|---|
+| ≤ 0.9.0 | `connect-python` | Original name. Imported as `connectrpc`. |
+| ≥ 0.10.0 | `connectrpc` | Distribution renamed by upstream. **Pin `>=0.10.0`** so resolvers skip the squatted v0.0.1 by Gaudiy. |
 
-Always `pip install connect-python`, never `pip install connectrpc`.
+The lesson: the same PyPI name can mean different things across versions. Pin the floor (`>=0.10.0`) — never `>=0.0.1` — so the squat can't satisfy the constraint.
 
 ---
 
@@ -322,6 +322,6 @@ The `_parse_wsgi_headers()` function in `middleware_wsgi.py` converts all `HTTP_
 | Want | Don't Use | Use Instead | Why |
 |------|-----------|-------------|-----|
 | Keccak256 | `pysha3`, `hashlib.sha3_256` | `pycryptodome` (`Crypto.Hash.keccak`) | py3.13 compat, correct padding |
-| ConnectRPC | `connectrpc` (PyPI) | `connect-python` (PyPI) | Wrong package on PyPI |
+| ConnectRPC | `connectrpc<0.10` (squatted v0.0.1) | `connectrpc>=0.10.0` | Distribution renamed from `connect-python` at v0.10.0 |
 | buf.validate stubs | `protovalidate`, BSR index | `buf generate --include-imports` | Self-contained, no external index |
 | Async subprocess | `subprocess.run()` | `asyncio.create_subprocess_exec()` | Non-blocking in event loop |

--- a/docs/python/PLAN.md
+++ b/docs/python/PLAN.md
@@ -1,5 +1,7 @@
 # Python Provider SDK + Starter - Implementation Plan
 
+> **Historical note (post-implementation):** the ConnectRPC PyPI distribution was renamed from `connect-python` to `connectrpc` at v0.10.0, and `protoc-gen-connect-python` to `protoc-gen-connectrpc`. Module imports are unchanged (`connectrpc.X`). Current floor pins are tracked in `python/CLAUDE.md`; the package names in this plan reflect the original (pre-rename) state and are preserved for historical accuracy.
+
 ## Context
 
 The T-0 Network needs a Python provider SDK and starter, matching the existing Go SDK (golden standard) and Java SDK. The Python SDK will use ConnectRPC protocol (like Go, NOT gRPC), live in a single repository with both SDK and starter, and provide one-line project initialization for Python developers joining the T-0 network.

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -59,13 +59,13 @@ python/
 
 | Package | PyPI | Import | Purpose |
 |---------|------|--------|---------|
-| connect-python | `connect-python>=0.8` | `connectrpc` | ConnectRPC runtime |
+| connectrpc | `connectrpc>=0.10.0` | `connectrpc` | ConnectRPC runtime (renamed from `connect-python` at v0.10.0) |
 | pyqwest | (transitive) | `pyqwest` | HTTP client (Rust-backed) |
 | protobuf | `protobuf>=7.34` | `google.protobuf` | Message serialization |
 | coincurve | `coincurve>=21.0` | `coincurve` | secp256k1 ECDSA |
 | pycryptodome | `pycryptodome>=3.23` | `Crypto.Hash.keccak` | Keccak256 |
 
-**DO NOT use:** `pysha3` (incompatible with Python 3.13), `hashlib.sha3_256()` (different padding from Keccak256), `connectrpc` from PyPI (different package v0.0.1 by Gaudiy).
+**DO NOT use:** `pysha3` (incompatible with Python 3.13), `hashlib.sha3_256()` (different padding from Keccak256). Note: `connectrpc` on PyPI is the official ConnectRPC Python runtime as of v0.10.0; pin `>=0.10.0` to skip the older squatted v0.0.1.
 
 ## ConnectRPC Python Specifics
 
@@ -104,7 +104,7 @@ Validates: Keccak256 hash, public key derivation, bidirectional signature verifi
 
 ## SystemService & Versioning
 
-`new_asgi_app` / `new_wsgi_app` in `provider/handler.py` auto-register `tzero.v1.system.SystemService` (impl in `provider/system.py`). Runtime version: `_version.py` (`__version__`). Full design + maintenance details: [`docs/SYSTEM_SERVICE.md`](../docs/SYSTEM_SERVICE.md), [`docs/VERSIONING.md`](../docs/VERSIONING.md). **Gotcha:** the generated `tzero/v1/system/system_connect.py` has a manual patch (codec import + kwarg removed) for connect-python 0.9.0 compatibility — re-apply after any `buf generate` until the buf plugin is pinned.
+`new_asgi_app` / `new_wsgi_app` in `provider/handler.py` auto-register `tzero.v1.system.SystemService` (impl in `provider/system.py`). Runtime version: `_version.py` (`__version__`). Full design + maintenance details: [`docs/SYSTEM_SERVICE.md`](../docs/SYSTEM_SERVICE.md), [`docs/VERSIONING.md`](../docs/VERSIONING.md).
 
 ## Architecture (Go SDK Mapping)
 

--- a/python/README.md
+++ b/python/README.md
@@ -176,4 +176,4 @@ docker run --env-file .env -p 8080:8080 my-provider
 
 **Signature verification failures** -- Ensure the server clock is synchronized (NTP). Timestamps outside +/- 60 seconds are rejected. Verify that `NETWORK_PUBLIC_KEY` matches the key provided by the T-0 team.
 
-**`pip install connectrpc` installs the wrong package** -- The correct PyPI package is `connect-python` (which imports as `connectrpc`). The `connectrpc` package on PyPI is a different, unmaintained package. The SDK's `pyproject.toml` already depends on the correct package.
+**ConnectRPC PyPI package** -- The package is `connectrpc` (renamed from `connect-python` at v0.10.0). The SDK's `pyproject.toml` pins `connectrpc>=0.10.0`, which resolves to the official runtime. Earlier docs warned about a squatted v0.0.1 on the same PyPI name; that release pre-dates 0.9.0 and pinning `>=0.10.0` skips it.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,7 +25,7 @@ strict = true
 
 [dependency-groups]
 dev = [
-    "protoc-gen-connect-python>=0.8.1",
+    "protoc-gen-connectrpc>=0.10.0",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "ruff>=0.8",

--- a/python/sdk/pyproject.toml
+++ b/python/sdk/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "T-0 Network" },
 ]
 dependencies = [
-    "connect-python>=0.9",
+    "connectrpc>=0.10.0",
     "protobuf>=7.34.1",
     "coincurve>=21.0",
     "pycryptodome>=3.23",

--- a/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment/network_connect.py
+++ b/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment/network_connect.py
@@ -7,6 +7,7 @@ from typing import Protocol
 
 from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
+from connectrpc.codec import Codec
 from connectrpc.compression import Compression
 from connectrpc.errors import ConnectError
 from connectrpc.interceptor import Interceptor, InterceptorSync
@@ -37,7 +38,7 @@ class NetworkService(Protocol):
 
 
 class NetworkServiceASGIApplication(ConnectASGIApplication[NetworkService]):
-    def __init__(self, service: NetworkService | AsyncGenerator[NetworkService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: NetworkService | AsyncGenerator[NetworkService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             service=service,
             endpoints=lambda svc: {
@@ -105,6 +106,7 @@ class NetworkServiceASGIApplication(ConnectASGIApplication[NetworkService]):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -237,6 +239,9 @@ class NetworkServiceClient(ConnectClient):
         )
 
 
+
+
+
 class NetworkServiceSync(Protocol):
     def update_quote(self, request: tzero_dot_v1_dot_payment_dot_network__pb2.UpdateQuoteRequest, ctx: RequestContext) -> tzero_dot_v1_dot_payment_dot_network__pb2.UpdateQuoteResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
@@ -253,7 +258,7 @@ class NetworkServiceSync(Protocol):
 
 
 class NetworkServiceWSGIApplication(ConnectWSGIApplication):
-    def __init__(self, service: NetworkServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: NetworkServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             endpoints={
                 "/tzero.v1.payment.NetworkService/UpdateQuote": EndpointSync.unary(
@@ -320,6 +325,7 @@ class NetworkServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -450,3 +456,5 @@ class NetworkServiceClientSync(ConnectClientSync):
             headers=headers,
             timeout_ms=timeout_ms,
         )
+
+

--- a/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment/provider_connect.py
+++ b/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment/provider_connect.py
@@ -7,6 +7,7 @@ from typing import Protocol
 
 from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
+from connectrpc.codec import Codec
 from connectrpc.compression import Compression
 from connectrpc.errors import ConnectError
 from connectrpc.interceptor import Interceptor, InterceptorSync
@@ -34,7 +35,7 @@ class ProviderService(Protocol):
 
 
 class ProviderServiceASGIApplication(ConnectASGIApplication[ProviderService]):
-    def __init__(self, service: ProviderService | AsyncGenerator[ProviderService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: ProviderService | AsyncGenerator[ProviderService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             service=service,
             endpoints=lambda svc: {
@@ -92,6 +93,7 @@ class ProviderServiceASGIApplication(ConnectASGIApplication[ProviderService]):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -202,6 +204,9 @@ class ProviderServiceClient(ConnectClient):
         )
 
 
+
+
+
 class ProviderServiceSync(Protocol):
     def pay_out(self, request: tzero_dot_v1_dot_payment_dot_provider__pb2.PayoutRequest, ctx: RequestContext) -> tzero_dot_v1_dot_payment_dot_provider__pb2.PayoutResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
@@ -216,7 +221,7 @@ class ProviderServiceSync(Protocol):
 
 
 class ProviderServiceWSGIApplication(ConnectWSGIApplication):
-    def __init__(self, service: ProviderServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: ProviderServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             endpoints={
                 "/tzero.v1.payment.ProviderService/PayOut": EndpointSync.unary(
@@ -273,6 +278,7 @@ class ProviderServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -381,3 +387,5 @@ class ProviderServiceClientSync(ConnectClientSync):
             headers=headers,
             timeout_ms=timeout_ms,
         )
+
+

--- a/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment_intent/beneficiary_connect.py
+++ b/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment_intent/beneficiary_connect.py
@@ -7,6 +7,7 @@ from typing import Protocol
 
 from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
+from connectrpc.codec import Codec
 from connectrpc.compression import Compression
 from connectrpc.errors import ConnectError
 from connectrpc.interceptor import Interceptor, InterceptorSync
@@ -22,7 +23,7 @@ class BeneficiaryService(Protocol):
 
 
 class BeneficiaryServiceASGIApplication(ConnectASGIApplication[BeneficiaryService]):
-    def __init__(self, service: BeneficiaryService | AsyncGenerator[BeneficiaryService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: BeneficiaryService | AsyncGenerator[BeneficiaryService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             service=service,
             endpoints=lambda svc: {
@@ -40,6 +41,7 @@ class BeneficiaryServiceASGIApplication(ConnectASGIApplication[BeneficiaryServic
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -70,13 +72,16 @@ class BeneficiaryServiceClient(ConnectClient):
         )
 
 
+
+
+
 class BeneficiaryServiceSync(Protocol):
     def payment_intent_update(self, request: tzero_dot_v1_dot_payment__intent_dot_beneficiary__pb2.PaymentIntentUpdateRequest, ctx: RequestContext) -> tzero_dot_v1_dot_payment__intent_dot_beneficiary__pb2.PaymentIntentUpdateResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
 
 
 class BeneficiaryServiceWSGIApplication(ConnectWSGIApplication):
-    def __init__(self, service: BeneficiaryServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: BeneficiaryServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             endpoints={
                 "/tzero.v1.payment_intent.BeneficiaryService/PaymentIntentUpdate": EndpointSync.unary(
@@ -93,6 +98,7 @@ class BeneficiaryServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -121,3 +127,5 @@ class BeneficiaryServiceClientSync(ConnectClientSync):
             headers=headers,
             timeout_ms=timeout_ms,
         )
+
+

--- a/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment_intent/network_connect.py
+++ b/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment_intent/network_connect.py
@@ -7,6 +7,7 @@ from typing import Protocol
 
 from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
+from connectrpc.codec import Codec
 from connectrpc.compression import Compression
 from connectrpc.errors import ConnectError
 from connectrpc.interceptor import Interceptor, InterceptorSync
@@ -31,7 +32,7 @@ class PaymentIntentService(Protocol):
 
 
 class PaymentIntentServiceASGIApplication(ConnectASGIApplication[PaymentIntentService]):
-    def __init__(self, service: PaymentIntentService | AsyncGenerator[PaymentIntentService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: PaymentIntentService | AsyncGenerator[PaymentIntentService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             service=service,
             endpoints=lambda svc: {
@@ -79,6 +80,7 @@ class PaymentIntentServiceASGIApplication(ConnectASGIApplication[PaymentIntentSe
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -169,6 +171,9 @@ class PaymentIntentServiceClient(ConnectClient):
         )
 
 
+
+
+
 class PaymentIntentServiceSync(Protocol):
     def update_quote(self, request: tzero_dot_v1_dot_payment__intent_dot_network__pb2.UpdateQuoteRequest, ctx: RequestContext) -> tzero_dot_v1_dot_payment__intent_dot_network__pb2.UpdateQuoteResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
@@ -181,7 +186,7 @@ class PaymentIntentServiceSync(Protocol):
 
 
 class PaymentIntentServiceWSGIApplication(ConnectWSGIApplication):
-    def __init__(self, service: PaymentIntentServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: PaymentIntentServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             endpoints={
                 "/tzero.v1.payment_intent.PaymentIntentService/UpdateQuote": EndpointSync.unary(
@@ -228,6 +233,7 @@ class PaymentIntentServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -316,3 +322,5 @@ class PaymentIntentServiceClientSync(ConnectClientSync):
             headers=headers,
             timeout_ms=timeout_ms,
         )
+
+

--- a/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment_intent/pay_in_provider_connect.py
+++ b/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment_intent/pay_in_provider_connect.py
@@ -7,6 +7,7 @@ from typing import Protocol
 
 from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
+from connectrpc.codec import Codec
 from connectrpc.compression import Compression
 from connectrpc.errors import ConnectError
 from connectrpc.interceptor import Interceptor, InterceptorSync
@@ -22,7 +23,7 @@ class PayInProviderService(Protocol):
 
 
 class PayInProviderServiceASGIApplication(ConnectASGIApplication[PayInProviderService]):
-    def __init__(self, service: PayInProviderService | AsyncGenerator[PayInProviderService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: PayInProviderService | AsyncGenerator[PayInProviderService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             service=service,
             endpoints=lambda svc: {
@@ -40,6 +41,7 @@ class PayInProviderServiceASGIApplication(ConnectASGIApplication[PayInProviderSe
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -70,13 +72,16 @@ class PayInProviderServiceClient(ConnectClient):
         )
 
 
+
+
+
 class PayInProviderServiceSync(Protocol):
     def get_payment_details(self, request: tzero_dot_v1_dot_payment__intent_dot_pay__in__provider__pb2.GetPaymentDetailsRequest, ctx: RequestContext) -> tzero_dot_v1_dot_payment__intent_dot_pay__in__provider__pb2.GetPaymentDetailsResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
 
 
 class PayInProviderServiceWSGIApplication(ConnectWSGIApplication):
-    def __init__(self, service: PayInProviderServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: PayInProviderServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             endpoints={
                 "/tzero.v1.payment_intent.PayInProviderService/GetPaymentDetails": EndpointSync.unary(
@@ -93,6 +98,7 @@ class PayInProviderServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -121,3 +127,5 @@ class PayInProviderServiceClientSync(ConnectClientSync):
             headers=headers,
             timeout_ms=timeout_ms,
         )
+
+

--- a/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment_intent/provider/provider_connect.py
+++ b/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment_intent/provider/provider_connect.py
@@ -7,6 +7,7 @@ from typing import Protocol
 
 from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
+from connectrpc.codec import Codec
 from connectrpc.compression import Compression
 from connectrpc.errors import ConnectError
 from connectrpc.interceptor import Interceptor, InterceptorSync
@@ -28,7 +29,7 @@ class NetworkService(Protocol):
 
 
 class NetworkServiceASGIApplication(ConnectASGIApplication[NetworkService]):
-    def __init__(self, service: NetworkService | AsyncGenerator[NetworkService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: NetworkService | AsyncGenerator[NetworkService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             service=service,
             endpoints=lambda svc: {
@@ -66,6 +67,7 @@ class NetworkServiceASGIApplication(ConnectASGIApplication[NetworkService]):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -135,8 +137,6 @@ class NetworkServiceClient(ConnectClient):
             timeout_ms=timeout_ms,
         )
 
-
-
 class ProviderService(Protocol):
     async def create_payment_intent(self, request: tzero_dot_v1_dot_payment__intent_dot_provider_dot_provider__pb2.CreatePaymentIntentRequest, ctx: RequestContext) -> tzero_dot_v1_dot_payment__intent_dot_provider_dot_provider__pb2.CreatePaymentIntentResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
@@ -146,7 +146,7 @@ class ProviderService(Protocol):
 
 
 class ProviderServiceASGIApplication(ConnectASGIApplication[ProviderService]):
-    def __init__(self, service: ProviderService | AsyncGenerator[ProviderService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: ProviderService | AsyncGenerator[ProviderService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             service=service,
             endpoints=lambda svc: {
@@ -174,6 +174,7 @@ class ProviderServiceASGIApplication(ConnectASGIApplication[ProviderService]):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -224,6 +225,9 @@ class ProviderServiceClient(ConnectClient):
         )
 
 
+
+
+
 class NetworkServiceSync(Protocol):
     def confirm_payment(self, request: tzero_dot_v1_dot_payment__intent_dot_provider_dot_provider__pb2.ConfirmPaymentRequest, ctx: RequestContext) -> tzero_dot_v1_dot_payment__intent_dot_provider_dot_provider__pb2.ConfirmPaymentResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
@@ -234,7 +238,7 @@ class NetworkServiceSync(Protocol):
 
 
 class NetworkServiceWSGIApplication(ConnectWSGIApplication):
-    def __init__(self, service: NetworkServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: NetworkServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             endpoints={
                 "/tzero.v1.payment_intent.provider.NetworkService/ConfirmPayment": EndpointSync.unary(
@@ -271,6 +275,7 @@ class NetworkServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -348,7 +353,7 @@ class ProviderServiceSync(Protocol):
 
 
 class ProviderServiceWSGIApplication(ConnectWSGIApplication):
-    def __init__(self, service: ProviderServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: ProviderServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             endpoints={
                 "/tzero.v1.payment_intent.provider.ProviderService/CreatePaymentIntent": EndpointSync.unary(
@@ -375,6 +380,7 @@ class ProviderServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -423,3 +429,5 @@ class ProviderServiceClientSync(ConnectClientSync):
             headers=headers,
             timeout_ms=timeout_ms,
         )
+
+

--- a/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment_intent/recipient/recipient_connect.py
+++ b/python/sdk/src/t0_provider_sdk/api/tzero/v1/payment_intent/recipient/recipient_connect.py
@@ -7,6 +7,7 @@ from typing import Protocol
 
 from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
+from connectrpc.codec import Codec
 from connectrpc.compression import Compression
 from connectrpc.errors import ConnectError
 from connectrpc.interceptor import Interceptor, InterceptorSync
@@ -25,7 +26,7 @@ class NetworkService(Protocol):
 
 
 class NetworkServiceASGIApplication(ConnectASGIApplication[NetworkService]):
-    def __init__(self, service: NetworkService | AsyncGenerator[NetworkService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: NetworkService | AsyncGenerator[NetworkService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             service=service,
             endpoints=lambda svc: {
@@ -53,6 +54,7 @@ class NetworkServiceASGIApplication(ConnectASGIApplication[NetworkService]):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -104,8 +106,6 @@ class NetworkServiceClient(ConnectClient):
             use_get=use_get,
         )
 
-
-
 class RecipientService(Protocol):
     async def confirm_pay_in(self, request: tzero_dot_v1_dot_payment__intent_dot_recipient_dot_recipient__pb2.ConfirmPayInRequest, ctx: RequestContext) -> tzero_dot_v1_dot_payment__intent_dot_recipient_dot_recipient__pb2.ConfirmPayInResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
@@ -118,7 +118,7 @@ class RecipientService(Protocol):
 
 
 class RecipientServiceASGIApplication(ConnectASGIApplication[RecipientService]):
-    def __init__(self, service: RecipientService | AsyncGenerator[RecipientService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: RecipientService | AsyncGenerator[RecipientService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             service=service,
             endpoints=lambda svc: {
@@ -156,6 +156,7 @@ class RecipientServiceASGIApplication(ConnectASGIApplication[RecipientService]):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -226,6 +227,9 @@ class RecipientServiceClient(ConnectClient):
         )
 
 
+
+
+
 class NetworkServiceSync(Protocol):
     def create_payment_intent(self, request: tzero_dot_v1_dot_payment__intent_dot_recipient_dot_recipient__pb2.CreatePaymentIntentRequest, ctx: RequestContext) -> tzero_dot_v1_dot_payment__intent_dot_recipient_dot_recipient__pb2.CreatePaymentIntentResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
@@ -234,7 +238,7 @@ class NetworkServiceSync(Protocol):
 
 
 class NetworkServiceWSGIApplication(ConnectWSGIApplication):
-    def __init__(self, service: NetworkServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: NetworkServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             endpoints={
                 "/tzero.v1.payment_intent.recipient.NetworkService/CreatePaymentIntent": EndpointSync.unary(
@@ -261,6 +265,7 @@ class NetworkServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -322,7 +327,7 @@ class RecipientServiceSync(Protocol):
 
 
 class RecipientServiceWSGIApplication(ConnectWSGIApplication):
-    def __init__(self, service: RecipientServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: RecipientServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             endpoints={
                 "/tzero.v1.payment_intent.recipient.RecipientService/ConfirmPayIn": EndpointSync.unary(
@@ -359,6 +364,7 @@ class RecipientServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -427,3 +433,5 @@ class RecipientServiceClientSync(ConnectClientSync):
             headers=headers,
             timeout_ms=timeout_ms,
         )
+
+

--- a/python/sdk/src/t0_provider_sdk/api/tzero/v1/system/system_connect.py
+++ b/python/sdk/src/t0_provider_sdk/api/tzero/v1/system/system_connect.py
@@ -7,6 +7,7 @@ from typing import Protocol
 
 from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
+from connectrpc.codec import Codec
 from connectrpc.compression import Compression
 from connectrpc.errors import ConnectError
 from connectrpc.interceptor import Interceptor, InterceptorSync
@@ -22,7 +23,7 @@ class SystemService(Protocol):
 
 
 class SystemServiceASGIApplication(ConnectASGIApplication[SystemService]):
-    def __init__(self, service: SystemService | AsyncGenerator[SystemService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: SystemService | AsyncGenerator[SystemService], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             service=service,
             endpoints=lambda svc: {
@@ -40,6 +41,7 @@ class SystemServiceASGIApplication(ConnectASGIApplication[SystemService]):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property
@@ -81,7 +83,7 @@ class SystemServiceSync(Protocol):
 
 
 class SystemServiceWSGIApplication(ConnectWSGIApplication):
-    def __init__(self, service: SystemServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: SystemServiceSync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, codecs: Iterable[Codec] | None = None) -> None:
         super().__init__(
             endpoints={
                 "/tzero.v1.system.SystemService/Health": EndpointSync.unary(
@@ -98,6 +100,7 @@ class SystemServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            codecs=codecs,
         )
 
     @property

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -70,16 +70,16 @@ wheels = [
 ]
 
 [[package]]
-name = "connect-python"
-version = "0.9.0"
+name = "connectrpc"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
     { name = "pyqwest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/fc/0e4798c53e2754f5de36ecf4d198706cb23711d603df6c008f6e7b5b21ae/connect_python-0.9.0.tar.gz", hash = "sha256:a188ec843b0f5953b7e1b88061af50ad91c9aaa2e982d7a89a63ae5c1fff932e", size = 46094, upload-time = "2026-03-19T02:40:42.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/21/bb02a054348901d90d98a680864b2a97b6a89bd33285632821d3a1864e5a/connectrpc-0.10.0.tar.gz", hash = "sha256:44f89b70abae9f8192883e79e8a3317bdca555036ed3bd4a20f398c0bac7162f", size = 46893, upload-time = "2026-04-28T16:07:16.921Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/15/5b42df2d9d34e5103f2b69e4f6a4aeb47c52589eaac8d53eb5b0a40eabaa/connect_python-0.9.0-py3-none-any.whl", hash = "sha256:896171fa7236d4e1557e3f7eee76daa8c9dd762f2c21662515f2060f1b542574", size = 63381, upload-time = "2026-03-19T02:40:40.743Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/80/c701d8ea2013b32696d96ad76f841e7ce61bfb092a7d5dc823a15d87115c/connectrpc-0.10.0-py3-none-any.whl", hash = "sha256:fedaf5abb8c90ab69662958b88f23f4cc18b7a0b0359401d8e5776ccfceefc38", size = 64007, upload-time = "2026-04-28T16:07:15.59Z" },
 ]
 
 [[package]]
@@ -332,16 +332,16 @@ wheels = [
 ]
 
 [[package]]
-name = "protoc-gen-connect-python"
-version = "0.8.1"
+name = "protoc-gen-connectrpc"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/18/61737bae921b83c82a3191bad58d44f814e59e201973a71d866fd7b6e5ae/protoc_gen_connect_python-0.8.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11d06710d256af4ce2c7d6bc5ff47e9605692ef74e90042900681fd98a24a0c5", size = 1827152, upload-time = "2026-01-27T05:00:11.177Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/17/16bd1b44aac28659a39f69cb3b58d2fa32bb9b05ac3eb8ffa90e71c2a3ff/protoc_gen_connect_python-0.8.1-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:60ea034d17c8cb3ec889c0f759f79757c8952186cdde97f0e186df4d3e5b442b", size = 1950959, upload-time = "2026-01-27T05:00:13.242Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/15/08068c55366c25a5559ecf6ad643f7989d29f3acfd65a1a8e6f8f88b62b0/protoc_gen_connect_python-0.8.1-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:e6bf9d7e96d92b0c2af89ba62de9951db622c74614401a949facba5948309b69", size = 1761388, upload-time = "2026-01-27T05:00:15.06Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/dd/357c6134ac438d6fb6b393e2a2ef1e1aa0ab61c726b5b39c55c33a9ff295/protoc_gen_connect_python-0.8.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:f206ec49aa82c0b5bf22b623b6df5a954f296e0f4f07812ecf9a3590ec5c9a52", size = 1928422, upload-time = "2026-01-27T05:00:16.904Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/26/d4423db8a59aedd750b876dd1201aae1a7fc7e488c4688089d546247ea93/protoc_gen_connect_python-0.8.1-py3-none-win_amd64.whl", hash = "sha256:4cf8ce5c98aaf3f33505e335b9451bae3583a30e8eba1d546ebf0514711f684b", size = 1988042, upload-time = "2026-01-27T05:00:18.421Z" },
-    { url = "https://files.pythonhosted.org/packages/30/39/d7816afa15ce638dce0f406402042a87d01bae10b66d0322f6ea0524de3d/protoc_gen_connect_python-0.8.1-py3-none-win_arm64.whl", hash = "sha256:1d280ef7ea991f9864d18f66e27b3a3a2e55d7b2bc1e56bc333394b2f29b1bb0", size = 1793387, upload-time = "2026-01-27T05:00:19.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bc/78ad6d280ca2139aa08bd16a0997e495a2b721f8bc8f73676011195f3dd8/protoc_gen_connectrpc-0.10.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c51fcdd92a8a8d96b1b99e0c5bba52aebafc8fa1b4ca4f1e2e44d37c953438ba", size = 1911564, upload-time = "2026-04-28T16:07:26.956Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/58/1f9b1cd43d37a9de41798932f2d3160cd201df951be77ca2b090078d836a/protoc_gen_connectrpc-0.10.0-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:086b2c77bf6b391bcd2b3090b9ea737217abf21726153ae43310f8fcc3e59242", size = 2055543, upload-time = "2026-04-28T16:07:29.219Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/62/e4224b6e0d2042b748ba097822becbb59ed7678de1254bb4dd8b383b3bec/protoc_gen_connectrpc-0.10.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:19a49b08bbeff13da22c08d3ce969c7c1ed76ea308b4ec6f914955f68aef7215", size = 1852399, upload-time = "2026-04-28T16:07:30.806Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f7/32a200c015d31b8cea2576ce664937946c1c57fc58d5989157eecfc56fe6/protoc_gen_connectrpc-0.10.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:0d82b585544d2acd65c039134e9c5c744ee39e754fe2e8e7122f50b2141f5057", size = 2042545, upload-time = "2026-04-28T16:07:32.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/29/ef8b5590ead84a4ad7a832b916b7e0ff011230d04d83d35da42488244697/protoc_gen_connectrpc-0.10.0-py3-none-win_amd64.whl", hash = "sha256:907d2a49cfa0ea1adb3d2ff4b1c9119ca76750179d6ffcac5fc5c1060287965a", size = 2092079, upload-time = "2026-04-28T16:07:34.711Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/27/8667f57e386e9a59b9b5c139dbc14d5c15fe5e54b5b6722eaa6f3376092e/protoc_gen_connectrpc-0.10.0-py3-none-win_arm64.whl", hash = "sha256:179e6607b0c41b78ee78b83b96540f113d927c5a7d0113e47c2cf6a56b7df47b", size = 1872479, upload-time = "2026-04-28T16:07:36.133Z" },
 ]
 
 [[package]]
@@ -366,7 +366,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
-    { name = "protoc-gen-connect-python" },
+    { name = "protoc-gen-connectrpc" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -378,7 +378,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.14" },
-    { name = "protoc-gen-connect-python", specifier = ">=0.8.1" },
+    { name = "protoc-gen-connectrpc", specifier = ">=0.10.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.8" },
@@ -426,37 +426,37 @@ wheels = [
 
 [[package]]
 name = "pyqwest"
-version = "0.4.1"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/e3/cf7e1eaa975fff450f3886d6297a3041e37eb424c9a9f6531bab7c9d29b3/pyqwest-0.4.1.tar.gz", hash = "sha256:08ff72951861d2bbdd9e9e98e3ed710c81c47ec66652a5622645c68c71d9f609", size = 440370, upload-time = "2026-03-06T02:32:43.207Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/42/9328a1a057bc191e02514fbd8c9aa899e38ec29420491017f057ac6b5313/pyqwest-0.5.1.tar.gz", hash = "sha256:49535565a55a23830d376c6c0b8ca1276f19bb871e39330e1fbb3df69d9f02df", size = 448653, upload-time = "2026-04-17T03:56:00.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/5d/9322e9ae2d7053dd420339c38973176406c1f528cbdbb99a26008e7ea596/pyqwest-0.4.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:cf8014048ca9a7c5a2bc6501352e3bdc6883450c1dd5965ae3a488f721c199d4", size = 5059099, upload-time = "2026-04-11T04:20:41.838Z" },
-    { url = "https://files.pythonhosted.org/packages/65/59/509526fca743a4cfcb96374e08716aa0edbb97dabd65bfc4b02c54e60fea/pyqwest-0.4.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de88bfe87f4b0b9841999bb804bfc485caee4e4eea2540dd1e4126967addb4e6", size = 5447975, upload-time = "2026-04-11T04:20:43.586Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/3e/78dd63075455b2874f40666ea3f065ce437f27b7f90b3368f6849a585049/pyqwest-0.4.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b9b0027adb5c8f539cb1141fdf48969f9de34429362b8e52568ff546e982e17d", size = 5492016, upload-time = "2026-04-11T04:20:45.512Z" },
-    { url = "https://files.pythonhosted.org/packages/35/03/1ea620b8bc9abdc4f793d0a7b306e76fd2786f072f546494bb9b0108fbd1/pyqwest-0.4.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0ebda89631c47c0a46946e809f0a501b4a9ec457401fd4fa11541fa4be4602b5", size = 5610148, upload-time = "2026-04-11T04:20:47.19Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/98/56a3085fd5b9f8efe3259c7c463223dbbca9609d49475ecf2094ad5c6d64/pyqwest-0.4.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1f6c7349c40748c10d6ec670b577358b9a6438b75106b90a2d3a13591453e627", size = 5790336, upload-time = "2026-04-11T04:20:48.754Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/8c/452f80066ca1595f29761b2fbfd4ebcc7782d247fdf07dc970f4b42b8d02/pyqwest-0.4.1-cp310-abi3-win_amd64.whl", hash = "sha256:a8ad6b3b4ed422f71472d37087f000fdb45f5fd2d81c65c8376b1f4aa8eef0b1", size = 4638128, upload-time = "2026-04-11T04:20:51.08Z" },
-    { url = "https://files.pythonhosted.org/packages/17/bd/40b9d924b1eacaf29c5091920adddcb399953224884d47ba32ae2c14424b/pyqwest-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eef280656e939d4615286aec938814a0de8f6a32d19a0b01e401b41c7d2ffb5b", size = 5009765, upload-time = "2026-03-06T02:32:01.995Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/e1/4a6646fbd84f633bcf5baa0b12acf84f53c84aabea363cc8c00911d60da7/pyqwest-0.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:079695544599375395aed985e8c398154ecf5939366d10d7475565cb501d440b", size = 5373955, upload-time = "2026-03-06T02:32:03.567Z" },
-    { url = "https://files.pythonhosted.org/packages/66/69/21573dc1edab5bd76b1d77d83a628f22bd6a201f21ec4892af2e0d714e44/pyqwest-0.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4197a0798fa8233263ace3ddcb7967d4e4ebed60dd4162aced948fad94a7b2", size = 5417908, upload-time = "2026-03-06T02:32:05.348Z" },
-    { url = "https://files.pythonhosted.org/packages/03/22/8617b9f1e4a4d26f08b1d6aedfc0698dacd26f0c3f29bea100753f3df534/pyqwest-0.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:300145aa204b546ed952a8fa396ca5c96043fe7662d6d8fea9ed666cb787b378", size = 5541316, upload-time = "2026-03-06T02:32:06.929Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/23/a09b2e2b7679835b4f1a8cf15feaab84b875bada67e9fce8772701442dc5/pyqwest-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:de49b3193dfb684e4ca07a325b856889fb43a5b9ac52808a2c1549c0ad3b1d30", size = 5719921, upload-time = "2026-03-06T02:32:08.396Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/ee/a58a2e71dfa418c7c3d2426daa57357cb93cf2c9d8f9a0d8dceb20098470/pyqwest-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:da8996db7ef18a2394de12b465cf20cf1daa9fab7b9d3de731445166b6fd1a6b", size = 4596906, upload-time = "2026-03-06T02:32:10.134Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/6f/ed9be2ee96d209ba81467abf4c15f20973c676992597019399998adb5da0/pyqwest-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d1ae7a901f58c0d1456ce7012ccb60c4ef85cbc3d6daa9b17a43415b362a3f74", size = 5005846, upload-time = "2026-03-06T02:32:11.677Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/29/cb412b9e5b0a1f72cf63b5b551df18aa580aafa020f907fe27c794482362/pyqwest-0.4.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:588f95168779902a734db2a39af353768888a87aa1d91c93002a3132111e72b0", size = 5377385, upload-time = "2026-03-06T02:32:13.821Z" },
-    { url = "https://files.pythonhosted.org/packages/84/9e/be8c0192c2fb177834870de10ece2751cd38ca1d357908112a8da6a26106/pyqwest-0.4.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b97a3adfa54188029e93361bacb248ca81272d9085cb6189e4a2a2586c4346e", size = 5422653, upload-time = "2026-03-06T02:32:15.518Z" },
-    { url = "https://files.pythonhosted.org/packages/18/74/98afc627c0b91bb3e0214daf3dfbbd348d504574d4c6843a890a0dcc6f33/pyqwest-0.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2351d5b142e26df482c274d405185dc56f060559038a8e5e0e5feb8241bb4bb3", size = 5543025, upload-time = "2026-03-06T02:32:17.254Z" },
-    { url = "https://files.pythonhosted.org/packages/17/1d/c79c78103aa90a1eff56b5841c1f24bd4ca950957116387de1f1e3291066/pyqwest-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1fae17504ea83166e495fe93d9f2bfc22dc331dd68bca354a18597e3d1020984", size = 5723286, upload-time = "2026-03-06T02:32:18.8Z" },
-    { url = "https://files.pythonhosted.org/packages/24/5b/975b4275ee49cff860f5680dd4ed7f9d74c4c2294cc7c829012e69077e71/pyqwest-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:05320841aaa40af070ceb55bfd557f623b5f8aeca1831f97da79b5965775a549", size = 4596486, upload-time = "2026-03-06T02:32:20.813Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/ed/08ba859cf528451a9325e5a71c13db8b9aeb7cda794d1e6b7f4d3b3d581d/pyqwest-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:84e396c6ba396daa974dba2d7090264af26dcfce074d7812c2d7125602969da3", size = 5001684, upload-time = "2026-03-06T02:32:22.332Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/ed/b75026973f77cba73c2c6785107cd30407ca8285a7159a0a443801fdd30d/pyqwest-0.4.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f98b11081b3e0d117fda4e03fee6925d870c334fa35085362e980a44e118ab9", size = 5375558, upload-time = "2026-03-06T02:32:24.148Z" },
-    { url = "https://files.pythonhosted.org/packages/36/21/2b22d1117c440b020269dbd292f47890579ae5a78d14022a294eb558710b/pyqwest-0.4.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:952842d7f4935ff42d55fdfbf7f0538997b48c62e4aa9a20e4b42bce97ed82a4", size = 5424612, upload-time = "2026-03-06T02:32:25.663Z" },
-    { url = "https://files.pythonhosted.org/packages/74/9a/0b3d77903e0bfbfb6a836050aa08ff3d6efae332ce429980146dcd15b151/pyqwest-0.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:32e313d2357624a54e60f14976bdf22e41267871b913d51ec7b41be492a0c442", size = 5542133, upload-time = "2026-03-06T02:32:27.191Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/3b/fcbfa0f1e8a64ebca0b28ec8f638defddbba47461d755b33658347f8ed84/pyqwest-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:284e2c99cbebb257ff84c14f14aa87f658ebe57ddfc833aa1d2fd6a3c4687a37", size = 5724980, upload-time = "2026-03-06T02:32:29.102Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/d8/d6710bbb38f6a715135f7c8a8e5c6227d69299a2b7e989c81315a08054e7/pyqwest-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a7b8d8ae51ccf6375a9e82e5b38d2129ee3121acf4933a37e541f4fe04a5f758", size = 4577924, upload-time = "2026-03-06T02:32:31.013Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/48/a869484add1102bbedaf76b1e3840a3f34bb611bf9228ec89a03d51328b1/pyqwest-0.5.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:047078c4c3f7c93d8a1df07138c471cfdb234577f60563afe090b160ada1a132", size = 5058870, upload-time = "2026-04-17T03:54:36.807Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b7/f06e56398ea41a183a0494b6557d1e28ed122ac8a20315a7f24ec316b7c1/pyqwest-0.5.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f732aed3498abf5742f0c952f24fc21625d62fe0a701ec8e472257709540d61", size = 5438347, upload-time = "2026-04-17T03:54:39.108Z" },
+    { url = "https://files.pythonhosted.org/packages/39/df/6160cab1d48ad2d1a2038ac8a1ff94d72f267cb6a3e3a7181c1ae41d98c9/pyqwest-0.5.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77565ad8e551a101eddbf08328b0e3d54a179efec97a3da195ce831f0474ef92", size = 5457281, upload-time = "2026-04-17T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/56/343516d26e153a60c19f2dbbe83460238feddd18a27c42ae11f843e79bf1/pyqwest-0.5.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:57ea14094f841d735fcf401a6428e94a39aabf22d15762a979cf8d6096fea90b", size = 5600773, upload-time = "2026-04-17T03:54:43.615Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f3/56c2cca5b7fcf708d41628cd3bd8a8be48d364a33a469fc056a5e92d5de3/pyqwest-0.5.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e6716309fc179b0714978d1f8c32a70724b3b9f43acc9aea3cf9507872e631d6", size = 5763641, upload-time = "2026-04-17T03:54:45.804Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c1/ac5dceb438ec71f5a3aaf1d9481ddc3535cf875fa8c8ff3622758d49fe50/pyqwest-0.5.1-cp310-abi3-win_amd64.whl", hash = "sha256:736b560fd2256a41264f554243edf3ff872ead4da347392531576203cf97a4ce", size = 4638049, upload-time = "2026-04-17T03:54:48.108Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f6/5f5eaf7357ade38a5e8697935a156ac47ff3bef0bb9cc32ef2f5b4cf0190/pyqwest-0.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:81bf0feb6d07fc25ffbe96be09ef64ff732d444e26c80db1b1de999d74a7a7ed", size = 5054876, upload-time = "2026-04-17T03:55:04.992Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e8/3b17156c13745a17ce39c7bfe9ed9fdec8ba19a5a47ddd762c89f00fb642/pyqwest-0.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a7d2c4a162e72b57dfd175f53882558702c3ddd5704f536599f463e46081bd9", size = 5433361, upload-time = "2026-04-17T03:55:07.182Z" },
+    { url = "https://files.pythonhosted.org/packages/35/fc/a50cde1003e1c39c2087b1ae50cd074a41ab89f5a1ad2998cc3f481cf10c/pyqwest-0.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b33bcba509e07ee79e61f9311880a22e8c11a562382648166f624f0b480266c1", size = 5457142, upload-time = "2026-04-17T03:55:09.358Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/f8c50d2ebe3e6d41f04a9924baef9f106feec2eb87acdd60fcb1c3ce2e84/pyqwest-0.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3a7a7b56e0f9099b50dae2e5907f05fc5e61252cd48cc1561f156765b233dd7b", size = 5601185, upload-time = "2026-04-17T03:55:11.626Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/1f/13f250e31d5503d326da8d9874891bedbfd7eeaa86711ab15acce157e59f/pyqwest-0.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3cd54af62f01fd0daf694218074325ccbbea6527f27738a85fc1e38880119f0", size = 5761677, upload-time = "2026-04-17T03:55:13.915Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ab/11a1bf107af0f21fa8f1d9516e59c8b742c19c32f82cae49f6340ffa7336/pyqwest-0.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:938ac244f96730a8c1addb260cbec93e44ef63d73358285bafb00f18526c106b", size = 4631790, upload-time = "2026-04-17T03:55:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/f227c99b53890157b737aed6c0840ebedda8eaafb513d1db3092a85c12a3/pyqwest-0.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7755dd658c612016c38f0e26938b80dafd37d80ee074c5cc4301f54f385b1e52", size = 5058021, upload-time = "2026-04-17T03:55:18.237Z" },
+    { url = "https://files.pythonhosted.org/packages/26/14/c3924ee479fce346124ef07550262e4f91b1d0d6d14f3024d2c2efe38055/pyqwest-0.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29015b12242f2feeb24cbad7d1025a78b3239872efcbfa975ce23527e8c05ec7", size = 5420148, upload-time = "2026-04-17T03:55:20.446Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/7d/a8f45ea52cb97b410fad96597eccbf6be9417eb0a2bf7c0d6be9a936c897/pyqwest-0.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1271fb28a78484e93d09b7c78df5213900538af8cf5a53ce377ed2cbb82e72b2", size = 5443389, upload-time = "2026-04-17T03:55:22.914Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/47/9870f5e24f49f5c77fbc9d21f2a6ace3a065cc3c8411ae6d25001605ba5a/pyqwest-0.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:eaf970412356f9d6482045a8e7b7c9d36c07b6a7352c96c90a811e730eba906f", size = 5584772, upload-time = "2026-04-17T03:55:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a5/d5b81d67902f0526fb69ff0b71aa5fcadc052133fa4692aa35c7dbfd6c8e/pyqwest-0.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:986b787138893459e02485e89a7d4a383ec2864194a5ab7e0650dce9635f5215", size = 5746464, upload-time = "2026-04-17T03:55:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d7/49197597a26186c4a1e3cf0d915b04f0a15a52eaeb82ee8b1659ca131bab/pyqwest-0.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:4d9fb2bcbea6adc365ea3c69727b34dd21dee29edb1551b64531b25babb68f91", size = 4647610, upload-time = "2026-04-17T03:55:29.75Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a3/be43b05f7821e8fba21af2eaee3a8418979da40cf895042e1705aa63e394/pyqwest-0.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:dc7a7c65e839057bcc3a5d4f48c6c2202f89fc13ddb12bd8e2f20d95378a95d8", size = 5054843, upload-time = "2026-04-17T03:55:32.655Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e1/0e76b0bb3c71c87e63eebfcc1d5dfbee6ca69332336fea975defc30d8747/pyqwest-0.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e30c2268e9f7ec5509874047ebf83ecde1cab29d0bd7dc352fa2a782da2b2abf", size = 5432984, upload-time = "2026-04-17T03:55:34.925Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/98/f32513e74f30009eef6979632590df32287a19f85215dd5654a9676da184/pyqwest-0.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f632070abff4d0bfd0f6deada3beaaaa42a042809e50c7f2e2b25014687e070", size = 5452771, upload-time = "2026-04-17T03:55:37.44Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/40/334e2184dbc4641743f47cbaa0079c32239bdcb972aee659f37196b920fe/pyqwest-0.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:78f8b6b41c0206e9605d75b9fc3f20db97c266829f5a0bee8eff7d524de2bf20", size = 5598688, upload-time = "2026-04-17T03:55:39.808Z" },
+    { url = "https://files.pythonhosted.org/packages/16/cb/d1a80c6d3cc89207d02bf4abca856420efaecc4e9482fb1c3906f27228ba/pyqwest-0.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1d95a8a7e4246ba37dc3115b10b72c5dcdf4b226447d1a7a51973d686460fa4", size = 5759621, upload-time = "2026-04-17T03:55:41.956Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/57/eb4bc81fea27b0f0515e97168bb67145b9d7c81cd2f2f94f9deb0febd639/pyqwest-0.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fbd3232cca327bc591d47b0368ba712d929f66658d4822ac5129f5ede1a581df", size = 4623418, upload-time = "2026-04-17T03:55:44.129Z" },
 ]
 
 [[package]]
@@ -580,11 +580,11 @@ wheels = [
 
 [[package]]
 name = "t0-provider-sdk"
-version = "1.1.14"
+version = "1.1.15"
 source = { editable = "sdk" }
 dependencies = [
     { name = "coincurve" },
-    { name = "connect-python" },
+    { name = "connectrpc" },
     { name = "protobuf" },
     { name = "protovalidate" },
     { name = "pycryptodome" },
@@ -601,7 +601,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "coincurve", specifier = ">=21.0" },
-    { name = "connect-python", specifier = ">=0.9" },
+    { name = "connectrpc", specifier = ">=0.10.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
     { name = "protobuf", specifier = ">=7.34.1" },
     { name = "protovalidate", specifier = ">=0.3" },
@@ -614,7 +614,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "t0-provider-starter"
-version = "1.1.14"
+version = "1.1.15"
 source = { editable = "starter" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #87.

## Summary

- Bumps Python ConnectRPC runtime from `connect-python==0.9.0` (deprecated) to `connectrpc==0.10.0` — upstream renamed the PyPI distribution at v0.10.0 (module path `connectrpc.X` is unchanged).
- Pins all 8 previously-unpinned `buf.gen.yaml` plugins. The `connectrpc/python:v0.10.0` pin is the actual fix for #87; the other 7 match the version each language SDK already uses, so regen is a no-op for Go/Node/C#.
- Regenerates the 8 generated `*_connect.py` files (including `system_connect.py` from the merged SystemService PR #90) to the v0.10 plugin shape (adds `from connectrpc.codec import Codec` and a `codecs=` kwarg on every ASGI/WSGI Application `__init__`).
- Drops the now-obsolete "manual patch on `system_connect.py`" notes from `docs/SYSTEM_SERVICE.md` and `python/CLAUDE.md`, and the matching "Known gaps" entry about unpinned buf plugins.
- Drops the now-stale "DO NOT use connectrpc from PyPI" warning across 6 Python docs (the PyPI name is now the official one as of v0.10.0; `>=0.10.0` skips the squatted v0.0.1).

## Why this is required

`buf.gen.yaml` did not pin `buf.build/connectrpc/python`, so every `buf generate` picks the latest plugin. The 0.10 plugin emits a `codecs=` kwarg that the 0.9 runtime currently locked in `python/uv.lock` doesn't accept. PR #90 worked around this by manually patching `system_connect.py` and documenting "re-apply the patch after every `buf generate`." This PR resolves the underlying drift: the runtime + plugin pair now match at 0.10.0, the manual patch is gone, and pinning all plugins keeps regen reproducible.

## SDK source code: no changes

- `network/client.py` constructs clients with `(base_url, http_client=…, timeout_ms=…)` — still binds against the v0.10 client `__init__`.
- `provider/handler.py` passes only `interceptors=` to the generated Application classes; v0.10's new `codecs=None` default is filled by `get_default_codecs()`.
- `connectrpc.code.Code`, `connectrpc.errors.ConnectError`, `connectrpc.request.RequestContext`/`Headers` are byte-identical between v0.9.0 and v0.10.0 (verified against upstream tags).

## Behavioural note (no client-facing change)

Upstream PR [connectrpc/connect-python#219](https://github.com/connectrpc/connect-python/pull/219) makes non-`ConnectError` handler exceptions re-raise after sending the wire response (logged via `wsgi.errors` in WSGI). All SDK interceptors raise `ConnectError`, so what a caller sees is unchanged — only stderr visibility improves when an unrelated bug raises a plain `Exception`.

## Future upgrade workflow

Pinning is for reproducibility, not freezing. When a runtime SDK is bumped (Go/Node/Python/C#), bump the matching plugin pin in `buf.gen.yaml` in the same PR and run `buf generate`. The TODO in `buf.gen.yaml` is removed; a one-line note replaces it.

## Test plan

- [x] `uv run pytest sdk/tests` — **99/99 pass** (matches issue #87's stated baseline; includes PR #90's SystemService tests)
- [x] `uv run ruff check .` — clean
- [x] Smoke import: `from connectrpc.codec import Codec; from t0_provider_sdk.api.tzero.v1.system.system_connect import SystemServiceASGIApplication` — ok
- [x] `go test ./...` — green (verifies Go plugin pin produces no diff)
- [x] `npm run build && npm test` (node/sdk) — 23/23
- [x] `dotnet build && dotnet test` (csharp) — 54/54
- [x] Independent code review, completeness audit, behavioural compatibility review (3 parallel agents) — clean
- [ ] CI green

## Out of scope

- Java's `java/sdk/buf.gen.yaml` (already pinned).
- Bumping `connectrpc.com/connect` 1.19.1→1.19.2 in `go/go.mod` (open dependabot PR).
- `python/tests/cross_test/go_helper` build failure is pre-existing on master (its `go.mod` pins a Go module tag the local toolchain can't resolve) — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)