### PR TITLE
test(java): add framed-payload signature verification coverage + README terminology fix

### DIFF
--- a/java/sdk/README.md
+++ b/java/sdk/README.md
@@ -10,7 +10,7 @@ This document provides detailed technical documentation for developers who need 
 - [Architecture Overview](#architecture-overview)
 - [Critical: Raw Payload Bytes](#critical-raw-payload-bytes)
 - [Signature Format and Headers](#signature-format-and-headers)
-- [Protocol Support](#protocol-support)
+- [Accepted Signature Payload Formats](#accepted-signature-payload-formats)
 - [Thread Safety](#thread-safety)
 - [Usage Examples](#usage-examples)
 - [Error Handling](#error-handling)
@@ -72,7 +72,7 @@ Handles inbound requests from the t-0 Network with automatic signature verificat
 - Builder pattern for configuration
 - Configurable message sizes (default: 4MB inbound)
 - Automatic rejection of invalid/expired signatures
-- Support for both Connect and gRPC protocols
+- Inbound signature verification accepts both unframed and gRPC-framed signing payloads
 
 ### 3. Cryptography Layer (`network.t0.sdk.crypto`)
 
@@ -194,20 +194,21 @@ Where:
 
 ---
 
-## Protocol Support
+## Accepted Signature Payload Formats
 
-The SDK supports both Connect and gRPC protocols:
+The provider's `SignatureVerificationInterceptor` accepts signatures over either of two payload framings, allowing callers whose signing wiring sits at different layers in the gRPC stack:
 
-### Connect Protocol
-- HTTP body contains **raw protobuf bytes**
-- Signature computed over: `Keccak256(protobuf_bytes || timestamp)`
+### Unframed (signer above the gRPC framer)
+- Payload: raw protobuf message bytes
+- Signature computed over: `Keccak256(protobuf_bytes || timestamp_le_u64)`
+- Used by callers including the Java SDK's own `NetworkClient` and any Connect-protocol caller
 
-### gRPC Protocol
-- HTTP body contains **5-byte frame prefix + protobuf bytes**
+### gRPC-framed (signer below the gRPC framer)
+- Payload: 5-byte gRPC frame prefix followed by protobuf bytes
 - Frame format: `[0x00 (compression flag)] [4-byte length, big-endian]`
-- Signature computed over: `Keccak256(frame + protobuf_bytes || timestamp)`
+- Signature computed over: `Keccak256(frame || protobuf_bytes || timestamp_le_u64)`
 
-The `SignatureVerificationInterceptor` automatically tries both formats, enabling cross-protocol compatibility.
+The interceptor tries the unframed payload first, then reconstructs the gRPC frame and tries the framed payload. Both paths are load-bearing in production — see [`docs/java/SIGNATURE_VERIFICATION.md`](../../docs/java/SIGNATURE_VERIFICATION.md) for the full rationale.
 
 ---
 
@@ -398,7 +399,7 @@ Results are reported in operations per millisecond.
 1. **Re-serialization**: Message was deserialized and re-serialized before verification. Ensure you're using raw bytes.
 2. **Timestamp mismatch**: Client and server clocks are out of sync. Check system time.
 3. **Wrong public key**: Server is configured with a different public key than the client is using.
-4. **Protocol mismatch**: Client using Connect but server expecting gRPC framing (or vice versa).
+4. **Inconsistent payload framing**: Client computed the digest over different bytes than the server sees on the wire (e.g. signed pre-frame but framed bytes diverged due to compression flags). The verifier accepts either unframed or 5-byte-gRPC-framed payloads — but the signer's bytes must be self-consistent.
 
 **Debug Steps**:
 - Enable debug logging to see the exact bytes being signed/verified

--- a/java/sdk/src/test/java/network/t0/sdk/integration/SignatureVerificationIntegrationTest.java
+++ b/java/sdk/src/test/java/network/t0/sdk/integration/SignatureVerificationIntegrationTest.java
@@ -1,12 +1,31 @@
 package network.t0.sdk.integration;
 
+import io.grpc.Attributes;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 import io.grpc.StatusRuntimeException;
+import io.grpc.okhttp.OkHttpChannelBuilder;
 import io.grpc.stub.StreamObserver;
+import network.t0.sdk.common.Headers;
+import network.t0.sdk.crypto.Keccak256;
+import network.t0.sdk.crypto.SignResult;
 import network.t0.sdk.crypto.Signer;
 import network.t0.sdk.network.BlockingNetworkClient;
+import network.t0.sdk.network.ByteArrayMarshaller;
 import network.t0.sdk.provider.ProviderServer;
 import network.t0.sdk.proto.tzero.v1.payment.*;
 import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Clock;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -281,6 +300,233 @@ class SignatureVerificationIntegrationTest {
                     .withService(new TestProviderServiceImpl())
                     .build())
                     .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    // ==================== Framed-Payload Verification Tests (path 2) ====================
+
+    /**
+     * Exercises path 2 of {@link network.t0.sdk.provider.SignatureVerificationInterceptor#verifySignature}:
+     * signature computed over the gRPC-framed payload (5-byte frame prefix + protobuf bytes)
+     * rather than the unframed protobuf payload.
+     *
+     * <p>The Java SDK's own {@code NetworkClient} signs the unframed payload (path 1).
+     * Other callers — notably the T-0 Network when configured to call this provider via
+     * gRPC protocol — sign the framed payload because their signing wiring sits below the
+     * gRPC framer. Without these tests, removing path 2 would silently break those callers.
+     *
+     * <p>Implementation: a test-only client interceptor mirrors
+     * {@code NetworkClient.SigningClientInterceptor} structurally, differing only in what
+     * is hashed — the framed bytes instead of the unframed bytes.
+     */
+    @Nested
+    @DisplayName("Framed-Payload Signature Verification (path 2)")
+    class FramedPathTests {
+
+        @Test
+        @DisplayName("Signature over gRPC-framed payload should be accepted")
+        void framedSignature_validKey_shouldSucceed() throws Exception {
+            startServer(NETWORK_PUBLIC_KEY_HEX);
+            Signer networkSigner = Signer.fromHex(NETWORK_PRIVATE_KEY);
+
+            ManagedChannel channel = OkHttpChannelBuilder
+                    .forAddress("localhost", server.getPort())
+                    .usePlaintext()
+                    .build();
+            try {
+                Channel intercepted = ClientInterceptors.intercept(
+                        channel,
+                        new FramedPayloadSigningInterceptor(networkSigner, Clock.systemUTC()));
+                ProviderServiceGrpc.ProviderServiceBlockingStub stub =
+                        ProviderServiceGrpc.newBlockingStub(intercepted);
+
+                PayoutRequest request = PayoutRequest.newBuilder()
+                        .setPaymentId(12345)
+                        .setPayoutId(67890)
+                        .setCurrency("USD")
+                        .setClientQuoteId("framed-test")
+                        .build();
+
+                PayoutResponse response = stub.payOut(request);
+                assertThat(response.hasAccepted()).isTrue();
+            } finally {
+                channel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+            }
+        }
+
+        @Test
+        @DisplayName("Framed signature with wrong key should still be rejected")
+        void framedSignature_wrongKey_shouldReturnUnauthenticated() throws Exception {
+            startServer(NETWORK_PUBLIC_KEY_HEX);
+            Signer wrongSigner = Signer.fromHex(OTHER_PRIVATE_KEY);
+
+            ManagedChannel channel = OkHttpChannelBuilder
+                    .forAddress("localhost", server.getPort())
+                    .usePlaintext()
+                    .build();
+            try {
+                Channel intercepted = ClientInterceptors.intercept(
+                        channel,
+                        new FramedPayloadSigningInterceptor(wrongSigner, Clock.systemUTC()));
+                ProviderServiceGrpc.ProviderServiceBlockingStub stub =
+                        ProviderServiceGrpc.newBlockingStub(intercepted);
+
+                StatusRuntimeException exception = assertThrows(
+                        StatusRuntimeException.class,
+                        () -> stub.updateLimit(UpdateLimitRequest.getDefaultInstance()));
+
+                assertThat(exception.getStatus().getCode())
+                        .isEqualTo(io.grpc.Status.Code.UNAUTHENTICATED);
+            } finally {
+                channel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    /**
+     * Test-only client interceptor that signs the gRPC-framed payload (5-byte frame
+     * prefix + protobuf bytes) instead of the unframed protobuf payload. Mirrors the
+     * structure of {@code NetworkClient.SigningClientInterceptor}.
+     */
+    private static final class FramedPayloadSigningInterceptor implements ClientInterceptor {
+
+        private static final int GRPC_FRAME_HEADER_SIZE = 5;
+
+        private final Signer signer;
+        private final Clock clock;
+
+        FramedPayloadSigningInterceptor(Signer signer, Clock clock) {
+            this.signer = signer;
+            this.clock = clock;
+        }
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                MethodDescriptor<ReqT, RespT> method,
+                CallOptions callOptions,
+                Channel next) {
+
+            MethodDescriptor<byte[], RespT> rawMethod = method.toBuilder(
+                    ByteArrayMarshaller.INSTANCE,
+                    method.getResponseMarshaller()
+            ).build();
+
+            ClientCall<byte[], RespT> rawCall = next.newCall(rawMethod, callOptions);
+
+            return new ClientCall<ReqT, RespT>() {
+
+                private Listener<RespT> responseListener;
+                private Metadata headers;
+                private boolean started = false;
+                private int pendingRequests = 0;
+
+                @Override
+                public void start(Listener<RespT> responseListener, Metadata headers) {
+                    this.responseListener = responseListener;
+                    this.headers = headers;
+                }
+
+                @Override
+                public void sendMessage(ReqT message) {
+                    byte[] messageBytes;
+                    try (InputStream stream = method.getRequestMarshaller().stream(message)) {
+                        messageBytes = stream.readAllBytes();
+                    } catch (IOException e) {
+                        throw new RuntimeException("Failed to serialize message for signing", e);
+                    }
+
+                    long timestampMs = clock.millis();
+                    addFramedSignatureHeaders(messageBytes, timestampMs);
+
+                    if (!started) {
+                        rawCall.start(responseListener, headers);
+                        started = true;
+                        if (pendingRequests > 0) {
+                            rawCall.request(pendingRequests);
+                            pendingRequests = 0;
+                        }
+                    }
+
+                    rawCall.sendMessage(messageBytes);
+                }
+
+                @Override
+                public void halfClose() {
+                    if (!started) {
+                        long timestampMs = clock.millis();
+                        addFramedSignatureHeaders(new byte[0], timestampMs);
+                        rawCall.start(responseListener, headers);
+                        started = true;
+                        if (pendingRequests > 0) {
+                            rawCall.request(pendingRequests);
+                            pendingRequests = 0;
+                        }
+                    }
+                    rawCall.halfClose();
+                }
+
+                @Override
+                public void request(int numMessages) {
+                    if (started) {
+                        rawCall.request(numMessages);
+                    } else {
+                        pendingRequests += numMessages;
+                    }
+                }
+
+                @Override
+                public void cancel(String message, Throwable cause) {
+                    rawCall.cancel(message, cause);
+                }
+
+                @Override
+                public boolean isReady() {
+                    return rawCall.isReady();
+                }
+
+                @Override
+                public void setMessageCompression(boolean enabled) {
+                    rawCall.setMessageCompression(enabled);
+                }
+
+                @Override
+                public Attributes getAttributes() {
+                    return rawCall.getAttributes();
+                }
+
+                private void addFramedSignatureHeaders(byte[] messageBytes, long timestampMs) {
+                    byte[] timestampBytes = Headers.encodeTimestamp(timestampMs);
+                    byte[] framedBytes = grpcFrame(messageBytes);
+                    byte[] digest = Keccak256.hash(framedBytes, timestampBytes);
+                    SignResult signResult = signer.sign(digest);
+
+                    headers.put(
+                            Metadata.Key.of(Headers.SIGNATURE, Metadata.ASCII_STRING_MARSHALLER),
+                            signResult.getSignatureHex());
+                    headers.put(
+                            Metadata.Key.of(Headers.PUBLIC_KEY, Metadata.ASCII_STRING_MARSHALLER),
+                            signResult.getPublicKeyHex());
+                    headers.put(
+                            Metadata.Key.of(Headers.SIGNATURE_TIMESTAMP, Metadata.ASCII_STRING_MARSHALLER),
+                            String.valueOf(timestampMs));
+                }
+            };
+        }
+
+        /**
+         * Builds {@code [0x00 (compression flag)] [4-byte length, big-endian] [messageBytes]}.
+         * Matches {@code SignatureVerificationInterceptor.reconstructGrpcFrame}.
+         */
+        private static byte[] grpcFrame(byte[] messageBytes) {
+            byte[] framed = new byte[GRPC_FRAME_HEADER_SIZE + messageBytes.length];
+            framed[0] = 0;
+            int len = messageBytes.length;
+            framed[1] = (byte) ((len >> 24) & 0xFF);
+            framed[2] = (byte) ((len >> 16) & 0xFF);
+            framed[3] = (byte) ((len >> 8) & 0xFF);
+            framed[4] = (byte) (len & 0xFF);
+            System.arraycopy(messageBytes, 0, framed, GRPC_FRAME_HEADER_SIZE, messageBytes.length);
+            return framed;
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #92 (already merged). Two commits:

1. **`docs(java): clarify README dual-framing inbound verification wording`** — `java/sdk/README.md` previously said "The SDK supports both Connect and gRPC protocols", which conflated outbound transport (the Java SDK's `NetworkClient` is gRPC-only via `OkHttpChannelBuilder`) with inbound signature verification (the interceptor accepts both unframed and gRPC-framed signing payloads). Renames the section to "Accepted Signature Payload Formats" and reframes the two formats by where the signer sits relative to the gRPC framer — the actual distinguishing property. Also fixes the related Server Layer bullet and Troubleshooting "Protocol mismatch" item, which had the same imprecision.

2. **`test(java): add framed-payload signature verification coverage`** — path 2 of `SignatureVerificationInterceptor.verifySignature` (reconstructs the 5-byte gRPC frame and verifies against `frame || protobuf || timestamp`) had zero test coverage before this PR. The "DO NOT REMOVE" Javadoc added in #92 had no CI tripwire. Adds `FramedPathTests` (nested in `SignatureVerificationIntegrationTest`) with two cases:
   - **positive**: signature over the gRPC-framed payload is accepted. Server log confirms `"Signature verified against gRPC-framed body"`, proving path 2 is exercised.
   - **negative**: framed signature with the wrong key is rejected with `UNAUTHENTICATED`.

   Implementation uses a test-only `FramedPayloadSigningInterceptor` that mirrors `NetworkClient.SigningClientInterceptor` structurally, differing only in what is hashed (framed vs unframed). The interceptor uses `ByteArrayMarshaller` to ensure the bytes signed are byte-identical to those sent on the wire.

   Removing path 2 from `verifySignature` now turns `framedSignature_validKey_shouldSucceed` red — exactly the regression tripwire #89 was missing.

## Backward compatibility

- README change is doc-only; no API surface affected.
- Test addition: pure additive, no changes to production code.
- Build + full `:sdk:test` suite passes; new tests run in ~26ms.

## Test plan

- [x] `./gradlew :sdk:compileTestJava` passes
- [x] `./gradlew :sdk:test --tests "*FramedPathTests*"` — both new tests pass
- [x] `./gradlew :sdk:test` — full suite still green; no regressions in existing tests
- [x] Manual verification that path 2 is actually exercised: server log line `"Signature verified against gRPC-framed body"` appears in `framedSignature_validKey_shouldSucceed`'s system-out
- [ ] Reviewer confirms the duplicated interceptor structure in the test is acceptable (mirrors production interceptor by ~70 lines; alternative is a strategy-pattern refactor of production code, which felt like overreach for this PR)