### PR TITLE
feat(csharp): auto-register SystemService.Health()

### DIFF
--- a/csharp/sdk/T0.ProviderSdk.Tests/Provider/SystemServiceImplTests.cs
+++ b/csharp/sdk/T0.ProviderSdk.Tests/Provider/SystemServiceImplTests.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using Grpc.Core;
+using Grpc.Net.Client;
+using T0.ProviderSdk;
+using T0.ProviderSdk.Api.Tzero.V1.System;
+using T0.ProviderSdk.Crypto;
+using T0.ProviderSdk.Network;
+using T0.ProviderSdk.Provider;
+using T0.ProviderSdk.Tests.CrossTest;
+
+namespace T0.ProviderSdk.Tests.Provider;
+
+/// <summary>
+/// Tests for the auto-registered SystemService.
+///
+/// 1. Direct unit test of <c>SystemServiceImpl.Health()</c> response shape.
+/// 2. End-to-end via <c>T0ProviderServer.RunAsync</c>: a signed Health call
+///    succeeds and returns both the customer FQN and SystemService's own FQN.
+/// 3. Unsigned Health is rejected — proves the signature middleware also
+///    covers the auto-registered service.
+/// </summary>
+public class SystemServiceImplTests
+{
+    // Same dev keypair used in CrossServerTests.
+    private const string PrivateKey = "0x6b30303de7b26bfb1222b317a52113357f8bb06de00160b4261a2fef9c8b9bd8";
+    private const string PublicKey = "0x044fa1465c087aaf42e5ff707050b8f77d2ce92129c5f300686bdd3adfffe44567713bb7931632837c5268a832512e75599b6964f4484c9531c02e96d90384d9f0";
+
+    private const string PaymentServiceFqn = "tzero.v1.payment.ProviderService";
+    private const string SystemServiceFqn = "tzero.v1.system.SystemService";
+
+    private static readonly string ExpectedSdkVersion = ReadSdkVersionFromAssembly();
+
+    private static int FindFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static async Task WaitForPortAsync(int port, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                using var client = new TcpClient();
+                await client.ConnectAsync(IPAddress.Loopback, port);
+                return;
+            }
+            catch (SocketException)
+            {
+                await Task.Delay(100);
+            }
+        }
+        throw new TimeoutException($"Port {port} not ready after {timeout.TotalSeconds}s");
+    }
+
+    private static string ReadSdkVersionFromAssembly()
+    {
+        var raw = typeof(T0ProviderServer).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion ?? "unknown";
+        var plus = raw.IndexOf('+');
+        return plus >= 0 ? raw[..plus] : raw;
+    }
+
+    /// <summary>
+    /// Direct unit test: build a SystemServiceImpl with an FQN list and verify
+    /// the Health response shape mirrors what the proto contract requires.
+    /// </summary>
+    [Fact]
+    public async Task Health_ImplResponseShape()
+    {
+        var services = new List<string> { PaymentServiceFqn, SystemServiceFqn };
+        var impl = new SystemServiceImpl(services);
+
+        var before = DateTime.UtcNow;
+        var response = await impl.Health(new HealthRequest(), context: null!);
+        var after = DateTime.UtcNow;
+
+        Assert.Equal(services, response.Services);
+        Assert.Equal(ExpectedSdkVersion, response.SdkVersion);
+        Assert.Equal(SdkEcosystem.Csharp, response.SdkEcosystem);
+        Assert.NotNull(response.CurrentTime);
+        var currentTime = response.CurrentTime.ToDateTime();
+        Assert.InRange(currentTime, before.AddSeconds(-1), after.AddSeconds(1));
+    }
+
+    /// <summary>
+    /// End-to-end: T0ProviderServer auto-registers SystemService alongside the
+    /// customer's PaymentService. A signed Health call returns both FQNs.
+    /// </summary>
+    [Fact]
+    public async Task T0ProviderServer_AutoRegistersSystemService_SignedHealthSucceeds()
+    {
+        var port = FindFreePort();
+        var signer = Signer.FromHex(PrivateKey);
+        var dummyNetworkClient = NetworkClient.CreateNetworkServiceClient("http://localhost:1", signer);
+
+        var config = new T0Config
+        {
+            ProviderPrivateKey = PrivateKey,
+            NetworkPublicKey = PublicKey,
+            Port = port,
+            TZeroEndpoint = "http://localhost:1",
+        };
+
+        // Use args to enable HTTP/2 cleartext, mirroring the starter's appsettings.json
+        // which sets Kestrel:EndpointDefaults:Protocols=Http2.
+        var server = new T0ProviderServer(config, signer,
+            new[] { "--Kestrel:EndpointDefaults:Protocols=Http2" });
+        server.MapPaymentService<TestPaymentHandler>(dummyNetworkClient);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var serverTask = server.RunAsync(cts.Token);
+
+        try
+        {
+            await WaitForPortAsync(port, TimeSpan.FromSeconds(10));
+
+            using var channel = NetworkClient.Create(
+                new NetworkClientOptions { BaseUrl = $"http://127.0.0.1:{port}" },
+                signer);
+            var client = new SystemService.SystemServiceClient(channel);
+
+            var response = await client.HealthAsync(new HealthRequest());
+
+            Assert.Contains(PaymentServiceFqn, response.Services);
+            Assert.Contains(SystemServiceFqn, response.Services);
+            Assert.Equal(ExpectedSdkVersion, response.SdkVersion);
+            Assert.Equal(SdkEcosystem.Csharp, response.SdkEcosystem);
+            Assert.NotNull(response.CurrentTime);
+            var skew = (DateTime.UtcNow - response.CurrentTime.ToDateTime()).Duration();
+            Assert.True(skew < TimeSpan.FromSeconds(5), $"clock skew too large: {skew}");
+        }
+        finally
+        {
+            cts.Cancel();
+            try { await serverTask; }
+            catch (OperationCanceledException) { }
+        }
+    }
+
+    /// <summary>
+    /// Auto-registered SystemService inherits the SignatureVerificationMiddleware:
+    /// an unsigned request is rejected with InvalidArgument (missing public-key header).
+    /// </summary>
+    [Fact]
+    public async Task T0ProviderServer_SystemService_RejectsUnsignedRequest()
+    {
+        var port = FindFreePort();
+        var signer = Signer.FromHex(PrivateKey);
+        var dummyNetworkClient = NetworkClient.CreateNetworkServiceClient("http://localhost:1", signer);
+
+        var config = new T0Config
+        {
+            ProviderPrivateKey = PrivateKey,
+            NetworkPublicKey = PublicKey,
+            Port = port,
+            TZeroEndpoint = "http://localhost:1",
+        };
+
+        var server = new T0ProviderServer(config, signer,
+            new[] { "--Kestrel:EndpointDefaults:Protocols=Http2" });
+        server.MapPaymentService<TestPaymentHandler>(dummyNetworkClient);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var serverTask = server.RunAsync(cts.Token);
+
+        try
+        {
+            await WaitForPortAsync(port, TimeSpan.FromSeconds(10));
+
+            // Plain channel — no signing handler.
+            using var channel = GrpcChannel.ForAddress($"http://127.0.0.1:{port}");
+            var client = new SystemService.SystemServiceClient(channel);
+
+            var ex = await Assert.ThrowsAsync<RpcException>(() =>
+                client.HealthAsync(new HealthRequest()).ResponseAsync);
+            Assert.Equal(StatusCode.InvalidArgument, ex.StatusCode);
+        }
+        finally
+        {
+            cts.Cancel();
+            try { await serverTask; }
+            catch (OperationCanceledException) { }
+        }
+    }
+}

--- a/csharp/sdk/T0.ProviderSdk/Provider/SystemServiceImpl.cs
+++ b/csharp/sdk/T0.ProviderSdk/Provider/SystemServiceImpl.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using T0.ProviderSdk.Api.Tzero.V1.System;
+
+namespace T0.ProviderSdk.Provider;
+
+/// <summary>
+/// Auto-registered SystemService implementation. Returns the list of registered
+/// gRPC service FQNs, the server's current wall-clock time, the SDK version
+/// (read from the assembly's <see cref="AssemblyInformationalVersionAttribute"/>,
+/// which MSBuild populates from the <c>&lt;Version&gt;</c> element in the .csproj),
+/// and the SDK ecosystem identifier.
+/// </summary>
+internal sealed class SystemServiceImpl : SystemService.SystemServiceBase
+{
+    private static readonly string CachedSdkVersion = LoadSdkVersion();
+
+    private readonly IReadOnlyList<string> _services;
+
+    public SystemServiceImpl(IReadOnlyList<string> services)
+    {
+        _services = services;
+    }
+
+    public override Task<HealthResponse> Health(HealthRequest request, ServerCallContext context)
+    {
+        var response = new HealthResponse
+        {
+            CurrentTime = Timestamp.FromDateTime(DateTime.UtcNow),
+            SdkVersion = CachedSdkVersion,
+            SdkEcosystem = SdkEcosystem.Csharp,
+        };
+        response.Services.AddRange(_services);
+        return Task.FromResult(response);
+    }
+
+    private static string LoadSdkVersion()
+    {
+        var raw = typeof(SystemServiceImpl).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+        if (string.IsNullOrEmpty(raw))
+            return "unknown";
+        var plus = raw.IndexOf('+');
+        return plus >= 0 ? raw[..plus] : raw;
+    }
+}

--- a/csharp/sdk/T0.ProviderSdk/T0.ProviderSdk.csproj
+++ b/csharp/sdk/T0.ProviderSdk/T0.ProviderSdk.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="T0.ProviderSdk.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
     <PackageReference Include="Google.Protobuf" Version="3.34.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />

--- a/csharp/sdk/T0.ProviderSdk/T0ProviderServer.cs
+++ b/csharp/sdk/T0.ProviderSdk/T0ProviderServer.cs
@@ -7,6 +7,7 @@ using T0.ProviderSdk.Crypto;
 using T0.ProviderSdk.Provider;
 using PaymentApi = T0.ProviderSdk.Api.Tzero.V1.Payment;
 using PaymentIntentApi = T0.ProviderSdk.Api.Tzero.V1.PaymentIntent.Provider;
+using SystemApi = T0.ProviderSdk.Api.Tzero.V1.System;
 
 namespace T0.ProviderSdk;
 
@@ -19,6 +20,7 @@ public sealed class T0ProviderServer
     private readonly WebApplicationBuilder _builder;
     private readonly T0Config _config;
     private readonly List<Action<WebApplication>> _mapActions = [];
+    private readonly List<string> _registeredFqns = [];
 
     public T0ProviderServer(T0Config config, Signer signer, string[]? args = null)
     {
@@ -43,6 +45,7 @@ public sealed class T0ProviderServer
         PaymentApi.NetworkService.NetworkServiceClient networkClient)
         where THandler : PaymentApi.ProviderService.ProviderServiceBase
     {
+        _registeredFqns.Add(PaymentApi.ProviderService.Descriptor.FullName);
         _builder.Services.AddSingleton(networkClient);
         _mapActions.Add(app => app.MapGrpcService<THandler>());
         return this;
@@ -55,6 +58,7 @@ public sealed class T0ProviderServer
         PaymentIntentApi.NetworkService.NetworkServiceClient networkClient)
         where THandler : PaymentIntentApi.ProviderService.ProviderServiceBase
     {
+        _registeredFqns.Add(PaymentIntentApi.ProviderService.Descriptor.FullName);
         _builder.Services.AddSingleton(networkClient);
         _mapActions.Add(app => app.MapGrpcService<THandler>());
         return this;
@@ -70,10 +74,17 @@ public sealed class T0ProviderServer
     }
 
     /// <summary>
-    /// Builds and runs the provider server. Blocks until shutdown.
+    /// Builds and runs the provider server. Blocks until <paramref name="cancellationToken"/>
+    /// fires or the host shuts down.
     /// </summary>
-    public async Task RunAsync()
+    public async Task RunAsync(CancellationToken cancellationToken = default)
     {
+        var fqns = new List<string>(_registeredFqns)
+        {
+            SystemApi.SystemService.Descriptor.FullName,
+        };
+        _builder.Services.AddSingleton(new SystemServiceImpl(fqns));
+
         var app = _builder.Build();
 
         app.UseMiddleware<SignatureVerificationMiddleware>(
@@ -82,6 +93,8 @@ public sealed class T0ProviderServer
         foreach (var mapAction in _mapActions)
             mapAction(app);
 
-        await app.RunAsync();
+        app.MapGrpcService<SystemServiceImpl>();
+
+        await app.RunAsync(cancellationToken);
     }
 }

--- a/docs/SYSTEM_SERVICE.md
+++ b/docs/SYSTEM_SERVICE.md
@@ -67,7 +67,7 @@ Each SDK has a wrapper around server construction that the starter calls. Inside
 | Node | `createService` | [`node/sdk/src/service/service.ts`](../node/sdk/src/service/service.ts) |
 | Python | `new_asgi_app`, `new_wsgi_app` | [`python/sdk/src/t0_provider_sdk/provider/handler.py`](../python/sdk/src/t0_provider_sdk/provider/handler.py) |
 | Java | `ProviderServer.Builder.buildGrpcServer` | [`java/sdk/src/main/java/network/t0/sdk/provider/ProviderServer.java`](../java/sdk/src/main/java/network/t0/sdk/provider/ProviderServer.java) |
-| C# | *(not implemented yet — TODO at C# parity)* | — |
+| C# | `T0ProviderServer.RunAsync` | [`csharp/sdk/T0.ProviderSdk/T0ProviderServer.cs`](../csharp/sdk/T0.ProviderSdk/T0ProviderServer.cs) |
 
 The customer-facing FQN list returned by `Health.services` is collected at registration time:
 
@@ -75,12 +75,14 @@ The customer-facing FQN list returned by `Health.services` is collected at regis
 - **Node:** the user's `Router.service(desc, impl)` call is wrapped to capture `desc.typeName`.
 - **Python:** `routes.keys()` are stripped of leading `/` to recover FQNs.
 - **Java:** `BindableService.bindService().getServiceDescriptor().getName()` returns the FQN directly.
+- **C#:** each `MapPaymentService` / `MapPaymentIntentService` call appends `*.ProviderService.Descriptor.FullName` to a list; `RunAsync` adds `SystemService.Descriptor.FullName` and constructs `SystemServiceImpl` with the full list.
 
 Implementations live next to the wrapper:
 - Go: [`go/provider/system.go`](../go/provider/system.go)
 - Node: [`node/sdk/src/service/system.ts`](../node/sdk/src/service/system.ts)
 - Python: [`python/sdk/src/t0_provider_sdk/provider/system.py`](../python/sdk/src/t0_provider_sdk/provider/system.py)
 - Java: [`java/sdk/src/main/java/network/t0/sdk/provider/SystemServiceImpl.java`](../java/sdk/src/main/java/network/t0/sdk/provider/SystemServiceImpl.java)
+- C#: [`csharp/sdk/T0.ProviderSdk/Provider/SystemServiceImpl.cs`](../csharp/sdk/T0.ProviderSdk/Provider/SystemServiceImpl.cs)
 
 ### Adding a new RPC to SystemService
 
@@ -91,6 +93,7 @@ Implementations live next to the wrapper:
    - Node: add a method on the object returned by `createSystemServiceImpl`.
    - Python: add a method on both `SystemServiceImpl` (async, ASGI) and `SystemServiceImplSync` (WSGI).
    - Java: override the method on `SystemServiceImpl extends SystemServiceGrpc.SystemServiceImplBase`.
+   - C#: override the method on `SystemServiceImpl : SystemService.SystemServiceBase`.
 4. **Don't change any wrapper code** — the auto-registration loop already covers all RPCs of `SystemService`.
 5. **No customer code change** — the new RPC appears on every provider after they bump the SDK.
 
@@ -112,7 +115,9 @@ Implementations live next to the wrapper:
 
 **Node — public API contract.** The wrapped `Router` cast in `service.ts` is small (one method); if the underlying `ConnectRouter.service` signature changes, update the wrapper or starters break.
 
-**C# — not yet wired.** Generated stubs exist at [`csharp/sdk/T0.ProviderSdk/Api/Tzero/V1/System/`](../csharp/sdk/T0.ProviderSdk/Api/Tzero/V1/System/) but no equivalent of `SystemServiceImpl` or auto-registration is in place. Tracked for parity work when the C# SDK is published.
+**C# — runtime version read from assembly.** `SystemServiceImpl.LoadSdkVersion()` reads `AssemblyInformationalVersionAttribute`, which MSBuild auto-populates from the `<Version>` element in `T0.ProviderSdk.csproj`. Any `+gitsha` suffix (set when `IncludeSourceRevisionInInformationalVersion` is on) is stripped so the returned string is plain semver. No second source of truth — `release.yaml`'s `<Version>` bump is the only knob.
+
+**C# — Kestrel HTTP/2 from appsettings.** The starter's `appsettings.json` sets `Kestrel:EndpointDefaults:Protocols=Http2` so cleartext gRPC works. `T0ProviderServer` itself does not configure Kestrel; tests pass `--Kestrel:EndpointDefaults:Protocols=Http2` via the constructor's `args` parameter to mirror that setup.
 
 ### Future endpoints (design intent)
 
@@ -131,6 +136,7 @@ Examples that do **not** fit and should be separate services:
 ### Tests covering Health
 
 - Go: [`go/provider/system_test.go`](../go/provider/system_test.go) — three tests: response shape, fully-signed end-to-end through `network.NewServiceClient`, and unsigned-request rejection (proves signature middleware applies to Health).
+- C#: [`csharp/sdk/T0.ProviderSdk.Tests/Provider/SystemServiceImplTests.cs`](../csharp/sdk/T0.ProviderSdk.Tests/Provider/SystemServiceImplTests.cs) — three xUnit tests mirroring the Go set: direct impl shape, signed end-to-end through `T0ProviderServer.RunAsync`, and unsigned-request rejection.
 - Node, Python, Java: existing test suites build green; **no Health-specific tests yet** — see "Known gaps" below.
 
 ### Cross-language testing


### PR DESCRIPTION
## Summary

- Closes the C# parity gap from PR #90: `tzero.v1.system.SystemService` is now auto-registered by `T0ProviderServer` alongside the customer's payment / payment-intent services, matching Go / Node / Python / Java.
- New `SystemServiceImpl` returns the registered FQN list, server time, SDK version (read from the SDK assembly's `AssemblyInformationalVersionAttribute` — no second source of truth, no release/publish workflow changes), and `SdkEcosystem.Csharp`.
- `RunAsync` now accepts an optional `CancellationToken` (default-valued, backward-compatible) so tests can shut the host down cleanly.
- Three xUnit tests mirror `go/provider/system_test.go`: direct response shape, signed end-to-end through `T0ProviderServer` + a `TestPaymentHandler`, and unsigned-request rejection (proves the existing `SignatureVerificationMiddleware` covers Health).
- `docs/SYSTEM_SERVICE.md` updated — removed the C# TODO row and the "not yet wired" gotcha, added C# entries everywhere the other four SDKs were already listed.

## Why this is a real issue

Before this PR, customers using the published `T0.ProviderSdk` NuGet package did not get `Health()` even though `README.md` advertises C# as supported and `CLAUDE.md` states "Every SDK auto-registers `tzero.v1.system.SystemService`". `docs/SYSTEM_SERVICE.md` openly tracked the gap (`TODO at C# parity` on the table row, plus a "C# — not yet wired" gotcha block).

## Test plan

- [x] `cd csharp/sdk/T0.ProviderSdk && dotnet build` — clean
- [x] `cd csharp/sdk/T0.ProviderSdk.Tests && dotnet test` — 57 / 57 pass (3 new + 54 existing)
- [x] `cd csharp/starter/T0.ProviderStarter && dotnet build` — clean
- [ ] CI `build-csharp` job (will exercise the same `dotnet build` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)