### PR TITLE
test: Health tests for Node/Python/Java SDKs

### DIFF
--- a/docs/SYSTEM_SERVICE.md
+++ b/docs/SYSTEM_SERVICE.md
@@ -133,9 +133,13 @@ Examples that do **not** fit and should be separate services:
 
 ### Tests covering Health
 
-- Go: [`go/provider/system_test.go`](../go/provider/system_test.go) — three tests: response shape, fully-signed end-to-end through `network.NewServiceClient`, and unsigned-request rejection (proves signature middleware applies to Health).
-- C#: [`csharp/sdk/T0.ProviderSdk.Tests/Provider/SystemServiceImplTests.cs`](../csharp/sdk/T0.ProviderSdk.Tests/Provider/SystemServiceImplTests.cs) — three xUnit tests mirroring the Go set: direct impl shape, signed end-to-end through `T0ProviderServer.RunAsync`, and unsigned-request rejection.
-- Node, Python, Java: existing test suites build green; **no Health-specific tests yet** — see "Known gaps" below.
+Each language SDK has Go-canonical coverage of `Health`: a direct impl unit test, a signed end-to-end test through the public server-construction wrapper (which proves auto-registration AND that customer-FQN + SystemService-FQN both appear), and an unsigned-request rejection (proves the signature middleware also covers the auto-registered service).
+
+- Go: [`go/provider/system_test.go`](../go/provider/system_test.go).
+- Node: [`node/sdk/test/system.test.ts`](../node/sdk/test/system.test.ts).
+- Python: [`python/sdk/tests/provider/test_system.py`](../python/sdk/tests/provider/test_system.py) (impl shape, async + sync) + [`python/sdk/tests/integration/test_system_signed.py`](../python/sdk/tests/integration/test_system_signed.py) (signed E2E via `new_asgi_app` + unsigned rejection).
+- Java: [`java/sdk/src/test/java/network/t0/sdk/provider/SystemServiceImplTest.java`](../java/sdk/src/test/java/network/t0/sdk/provider/SystemServiceImplTest.java).
+- C#: [`csharp/sdk/T0.ProviderSdk.Tests/Provider/SystemServiceImplTests.cs`](../csharp/sdk/T0.ProviderSdk.Tests/Provider/SystemServiceImplTests.cs).
 
 ### Cross-language testing
 

--- a/java/sdk/src/test/java/network/t0/sdk/provider/SystemServiceImplTest.java
+++ b/java/sdk/src/test/java/network/t0/sdk/provider/SystemServiceImplTest.java
@@ -1,0 +1,251 @@
+package network.t0.sdk.provider;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import network.t0.sdk.crypto.Signer;
+import network.t0.sdk.network.BlockingNetworkClient;
+import network.t0.sdk.proto.tzero.v1.payment.AppendLedgerEntriesRequest;
+import network.t0.sdk.proto.tzero.v1.payment.AppendLedgerEntriesResponse;
+import network.t0.sdk.proto.tzero.v1.payment.ApprovePaymentQuoteRequest;
+import network.t0.sdk.proto.tzero.v1.payment.ApprovePaymentQuoteResponse;
+import network.t0.sdk.proto.tzero.v1.payment.PayoutRequest;
+import network.t0.sdk.proto.tzero.v1.payment.PayoutResponse;
+import network.t0.sdk.proto.tzero.v1.payment.ProviderServiceGrpc;
+import network.t0.sdk.proto.tzero.v1.payment.UpdateLimitRequest;
+import network.t0.sdk.proto.tzero.v1.payment.UpdateLimitResponse;
+import network.t0.sdk.proto.tzero.v1.payment.UpdatePaymentRequest;
+import network.t0.sdk.proto.tzero.v1.payment.UpdatePaymentResponse;
+import network.t0.sdk.proto.tzero.v1.system.HealthRequest;
+import network.t0.sdk.proto.tzero.v1.system.HealthResponse;
+import network.t0.sdk.proto.tzero.v1.system.SdkEcosystem;
+import network.t0.sdk.proto.tzero.v1.system.SystemServiceGrpc;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the auto-registered {@link SystemServiceImpl}.
+ *
+ * <p>Mirrors {@code go/provider/system_test.go} one-for-one:
+ * <ol>
+ *   <li>{@link #implResponseShape_returnsExpectedFields()} — direct unit test of the
+ *       package-private impl via {@link StreamObserver} capture.</li>
+ *   <li>{@link #autoRegisteredEndToEnd_signedHealthSucceeds()} — full Netty server via
+ *       {@link ProviderServer} + signed {@link BlockingNetworkClient} call to
+ *       {@code SystemService.Health}; both customer FQN and SystemService FQN must
+ *       appear in the response.</li>
+ *   <li>{@link #autoRegisteredEndToEnd_unsignedHealthRejected()} — same server, plain
+ *       channel without the signing interceptor; must fail with
+ *       {@link Status.Code#INVALID_ARGUMENT} (the code returned by
+ *       {@link SignatureVerificationInterceptor} for missing headers).</li>
+ * </ol>
+ *
+ * <p>This test lives in the {@code network.t0.sdk.provider} package so it has access to
+ * the package-private {@link SystemServiceImpl} constructor — that lets the impl-direct
+ * test exercise the real production class instead of a mirror.
+ */
+class SystemServiceImplTest {
+
+    // Same dev keypair used across the rest of the test suite.
+    private static final String NETWORK_PRIVATE_KEY =
+            "6b30303de7b26bfb1222b317a52113357f8bb06de00160b4261a2fef9c8b9bd8";
+    private static final String NETWORK_PUBLIC_KEY_HEX =
+            "044fa1465c087aaf42e5ff707050b8f77d2ce92129c5f300686bdd3adfffe44567713bb7931632837c5268a832512e75599b6964f4484c9531c02e96d90384d9f0";
+
+    private ProviderServer server;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (server != null) {
+            server.close();
+            server = null;
+        }
+    }
+
+    @Test
+    @DisplayName("SystemServiceImpl.health() returns configured services list, Java ecosystem, runtime version, fresh time")
+    void implResponseShape_returnsExpectedFields() {
+        List<String> services = List.of("example.v1.Foo", SystemServiceGrpc.SERVICE_NAME);
+        SystemServiceImpl impl = new SystemServiceImpl(services);
+
+        AtomicReference<HealthResponse> captured = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicBoolean completed = new AtomicBoolean(false);
+
+        Instant before = Instant.now();
+        impl.health(HealthRequest.getDefaultInstance(), new StreamObserver<>() {
+            @Override
+            public void onNext(HealthResponse value) {
+                captured.set(value);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                error.set(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                completed.set(true);
+            }
+        });
+        Instant after = Instant.now();
+
+        assertThat(error.get()).isNull();
+        assertThat(completed.get()).isTrue();
+
+        HealthResponse response = captured.get();
+        assertThat(response).isNotNull();
+
+        // Match Go's `require.Equal(services, resp.Msg.Services)` — exact list equality.
+        assertThat(response.getServicesList()).containsExactlyElementsOf(services);
+        assertThat(response.getSdkVersion()).isEqualTo(loadExpectedSdkVersion());
+        assertThat(response.getSdkEcosystem()).isEqualTo(SdkEcosystem.SDK_ECOSYSTEM_JAVA);
+        assertThat(response.hasCurrentTime()).isTrue();
+
+        Instant currentTime = Instant.ofEpochSecond(
+                response.getCurrentTime().getSeconds(), response.getCurrentTime().getNanos());
+        assertThat(currentTime).isBetween(before.minusSeconds(1), after.plusSeconds(1));
+    }
+
+    @Test
+    @DisplayName("Auto-registered SystemService: signed Health() returns customer FQN + system FQN over real Netty server")
+    void autoRegisteredEndToEnd_signedHealthSucceeds() throws Exception {
+        // Customer's exact pattern: register only the customer service via the public
+        // Builder API. SystemService gets auto-appended inside buildGrpcServer().
+        server = ProviderServer.create(0, NETWORK_PUBLIC_KEY_HEX)
+                .withService(new TestProviderServiceImpl())
+                .start();
+
+        Signer networkSigner = Signer.fromHex(NETWORK_PRIVATE_KEY);
+        try (BlockingNetworkClient<SystemServiceGrpc.SystemServiceBlockingStub> client =
+                     BlockingNetworkClient.create(
+                             "http://localhost:" + server.getPort(),
+                             networkSigner,
+                             SystemServiceGrpc::newBlockingStub)) {
+
+            HealthResponse response = client.stub().health(HealthRequest.getDefaultInstance());
+
+            assertThat(response.getServicesList())
+                    .contains(ProviderServiceGrpc.SERVICE_NAME)
+                    .contains(SystemServiceGrpc.SERVICE_NAME);
+            assertThat(response.getSdkVersion()).isEqualTo(loadExpectedSdkVersion());
+            assertThat(response.getSdkEcosystem()).isEqualTo(SdkEcosystem.SDK_ECOSYSTEM_JAVA);
+            assertThat(response.hasCurrentTime()).isTrue();
+
+            long skewSeconds = Math.abs(
+                    Instant.now().getEpochSecond() - response.getCurrentTime().getSeconds());
+            assertThat(skewSeconds).isLessThan(5);
+        }
+    }
+
+    @Test
+    @DisplayName("Auto-registered SystemService: unsigned Health() rejected with INVALID_ARGUMENT (missing headers)")
+    void autoRegisteredEndToEnd_unsignedHealthRejected() throws Exception {
+        server = ProviderServer.create(0, NETWORK_PUBLIC_KEY_HEX)
+                .withService(new TestProviderServiceImpl())
+                .start();
+
+        // Plain channel — no signing interceptor. The server's
+        // SignatureVerificationInterceptor must reject the call before it reaches
+        // SystemServiceImpl, proving the auto-registered service inherits the
+        // signature middleware.
+        ManagedChannel channel = NettyChannelBuilder
+                .forAddress("localhost", server.getPort())
+                .usePlaintext()
+                .build();
+        try {
+            SystemServiceGrpc.SystemServiceBlockingStub plainStub =
+                    SystemServiceGrpc.newBlockingStub(channel);
+
+            assertThatThrownBy(() -> plainStub.health(HealthRequest.getDefaultInstance()))
+                    .isInstanceOfSatisfying(StatusRuntimeException.class, ex ->
+                            assertThat(ex.getStatus().getCode())
+                                    .isEqualTo(Status.Code.INVALID_ARGUMENT));
+        } finally {
+            channel.shutdown();
+            channel.awaitTermination(2, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Reads the same {@code META-INF/sdk-version.properties} resource that
+     * {@link SystemServiceImpl} reads at runtime, so this test never drifts from
+     * whatever the SDK build pins as the runtime version.
+     */
+    private static String loadExpectedSdkVersion() {
+        try (InputStream in = SystemServiceImplTest.class.getResourceAsStream(
+                "/META-INF/sdk-version.properties")) {
+            assertThat(in).as("META-INF/sdk-version.properties on classpath").isNotNull();
+            Properties props = new Properties();
+            props.load(in);
+            String version = props.getProperty("sdk.version");
+            assertThat(version).as("sdk.version property").isNotNull();
+            return version;
+        } catch (IOException e) {
+            throw new AssertionError("failed to read sdk-version.properties", e);
+        }
+    }
+
+    /**
+     * Minimal customer service stub. All five RPCs return default-instance responses;
+     * we only need the binding to register {@code tzero.v1.payment.ProviderService}'s
+     * FQN with the server so we can assert it appears in the Health response.
+     */
+    private static final class TestProviderServiceImpl
+            extends ProviderServiceGrpc.ProviderServiceImplBase {
+
+        @Override
+        public void payOut(PayoutRequest request, StreamObserver<PayoutResponse> responseObserver) {
+            responseObserver.onNext(PayoutResponse.newBuilder()
+                    .setAccepted(PayoutResponse.Accepted.getDefaultInstance())
+                    .build());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void updatePayment(UpdatePaymentRequest request,
+                                  StreamObserver<UpdatePaymentResponse> responseObserver) {
+            responseObserver.onNext(UpdatePaymentResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void updateLimit(UpdateLimitRequest request,
+                                StreamObserver<UpdateLimitResponse> responseObserver) {
+            responseObserver.onNext(UpdateLimitResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void appendLedgerEntries(AppendLedgerEntriesRequest request,
+                                        StreamObserver<AppendLedgerEntriesResponse> responseObserver) {
+            responseObserver.onNext(AppendLedgerEntriesResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void approvePaymentQuotes(ApprovePaymentQuoteRequest request,
+                                         StreamObserver<ApprovePaymentQuoteResponse> responseObserver) {
+            responseObserver.onNext(ApprovePaymentQuoteResponse.newBuilder()
+                    .setAccepted(ApprovePaymentQuoteResponse.Accepted.getDefaultInstance())
+                    .build());
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/node/sdk/test/system.test.ts
+++ b/node/sdk/test/system.test.ts
@@ -15,9 +15,39 @@ import {
   SdkEcosystem,
   SystemService,
 } from '../src/common/gen/tzero/v1/system/system_pb.js';
+import { ProviderService } from '../src/common/gen/tzero/v1/payment/provider_pb.js';
 import { create } from '@bufbuild/protobuf';
-import { ConnectError, Code, createClient as createConnectClient } from '@connectrpc/connect';
+import {
+  ConnectError,
+  Code,
+  createClient as createConnectClient,
+  type ServiceImpl,
+} from '@connectrpc/connect';
 import { createConnectTransport } from '@connectrpc/connect-web';
+
+type RegisterRoutes = Parameters<typeof createService>[1];
+
+// Stub customer ProviderService — registered only so its FQN appears in the
+// SystemService.Health response. Methods are never invoked by these tests
+// (only SystemService.health is called), so each method just throws
+// Code.Unimplemented as a runtime safety net.
+const unimplementedProviderService: ServiceImpl<typeof ProviderService> = {
+  payOut() {
+    throw new ConnectError('unimplemented', Code.Unimplemented);
+  },
+  updatePayment() {
+    throw new ConnectError('unimplemented', Code.Unimplemented);
+  },
+  updateLimit() {
+    throw new ConnectError('unimplemented', Code.Unimplemented);
+  },
+  appendLedgerEntries() {
+    throw new ConnectError('unimplemented', Code.Unimplemented);
+  },
+  approvePaymentQuotes() {
+    throw new ConnectError('unimplemented', Code.Unimplemented);
+  },
+};
 
 function newKeypair() {
   const priv = Uint8Array.from(randomBytes(32));
@@ -28,12 +58,11 @@ function newKeypair() {
   };
 }
 
-async function bootServer(networkPublicKeyHex: string): Promise<{ url: string; close: () => Promise<void> }> {
-  const handler = connectNodeAdapter(
-    createService(networkPublicKeyHex, () => {
-      // No customer services — SystemService still gets auto-registered.
-    }),
-  );
+async function bootServer(
+  networkPublicKeyHex: string,
+  register: RegisterRoutes = () => {},
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const handler = connectNodeAdapter(createService(networkPublicKeyHex, register));
   const server = http.createServer(signatureValidation(handler));
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   const { port } = server.address() as AddressInfo;
@@ -57,12 +86,18 @@ describe('SystemService impl', () => {
 });
 
 describe('SystemService auto-registration', () => {
-  it('signed Health call returns SystemService FQN and Node ecosystem', async () => {
+  it('signed Health call returns customer FQN, SystemService FQN, and Node ecosystem', async () => {
     const { privateKeyHex, publicKeyHex } = newKeypair();
-    const { url, close } = await bootServer(publicKeyHex);
+    const { url, close } = await bootServer(publicKeyHex, (router) => {
+      router.service(ProviderService, unimplementedProviderService);
+    });
     try {
       const client = createClient(privateKeyHex, url, SystemService);
       const resp = await client.health({});
+      assert.ok(
+        resp.services.includes(ProviderService.typeName),
+        `services missing ProviderService: ${JSON.stringify(resp.services)}`,
+      );
       assert.ok(
         resp.services.includes(SystemService.typeName),
         `services missing SystemService: ${JSON.stringify(resp.services)}`,
@@ -70,6 +105,8 @@ describe('SystemService auto-registration', () => {
       assert.equal(resp.sdkVersion, SDK_VERSION);
       assert.equal(resp.sdkEcosystem, SdkEcosystem.NODE);
       assert.ok(resp.currentTime);
+      const skewMs = Math.abs(Date.now() - Number(resp.currentTime!.seconds) * 1000);
+      assert.ok(skewMs < 5_000, `currentTime skew = ${skewMs}ms`);
     } finally {
       await close();
     }

--- a/python/sdk/tests/integration/test_system_signed.py
+++ b/python/sdk/tests/integration/test_system_signed.py
@@ -1,24 +1,35 @@
-"""End-to-end integration test for the auto-registered SystemService.
+"""End-to-end integration tests for the auto-registered SystemService.
 
-Spins a uvicorn-served ASGI app via `new_asgi_app` (no customer services),
-calls `Health()` through `new_service_client` (which signs requests), and
-asserts the response shape matches what `SystemServiceImpl` returns.
+Mirrors `go/provider/system_test.go`:
+- a uvicorn-served ASGI app built via `new_asgi_app`, with a stub customer
+  ProviderService registered alongside the auto-registered SystemService;
+- a signed Health() call returns BOTH the customer FQN and SystemService's
+  own FQN, plus a fresh `current_time`, the runtime SDK version, and the
+  Python ecosystem identifier;
+- an unsigned Health() call is rejected with INVALID_ARGUMENT, proving the
+  signature middleware also covers the auto-registered service.
 """
 
 from __future__ import annotations
 
 import asyncio
 import socket
+import time
 
 import pytest
 import uvicorn
 from coincurve import PrivateKey
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
 from t0_provider_sdk._version import __version__
 from t0_provider_sdk.network.client import new_service_client
-from t0_provider_sdk.provider.handler import new_asgi_app
+from t0_provider_sdk.provider.handler import handler, new_asgi_app
+from tzero.v1.payment import provider_pb2 as payment_pb2
+from tzero.v1.payment.provider_connect import ProviderServiceASGIApplication
 from tzero.v1.system import system_pb2
 from tzero.v1.system.system_connect import SystemServiceClient
 
+PROVIDER_SERVICE_FQN = "tzero.v1.payment.ProviderService"
 SYSTEM_SERVICE_FQN = "tzero.v1.system.SystemService"
 
 
@@ -51,13 +62,36 @@ def _new_keypair() -> tuple[str, str]:
     )
 
 
+class _StubProviderService:
+    """Minimal async ProviderService — methods are never invoked, only the
+    registration matters so the FQN appears in the Health services list."""
+
+    async def pay_out(self, request, ctx):
+        return payment_pb2.PayoutResponse()
+
+    async def update_payment(self, request, ctx):
+        return payment_pb2.UpdatePaymentResponse()
+
+    async def update_limit(self, request, ctx):
+        return payment_pb2.UpdateLimitResponse()
+
+    async def append_ledger_entries(self, request, ctx):
+        return payment_pb2.AppendLedgerEntriesResponse()
+
+    async def approve_payment_quotes(self, request, ctx):
+        return payment_pb2.ApprovePaymentQuoteResponse()
+
+
 @pytest.mark.asyncio
 async def test_system_service_auto_registered_signed_e2e():
     private_key_hex, public_key_hex = _new_keypair()
     port = _find_free_port()
 
-    # No customer services — SystemService is still registered automatically.
-    app = new_asgi_app(public_key_hex)
+    # Customer ProviderService stub registered alongside the auto-registered SystemService.
+    app = new_asgi_app(
+        public_key_hex,
+        handler(ProviderServiceASGIApplication, _StubProviderService()),
+    )
 
     config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
     server = uvicorn.Server(config)
@@ -73,12 +107,46 @@ async def test_system_service_auto_registered_signed_e2e():
 
         response = await client.health(system_pb2.HealthRequest())
 
+        assert PROVIDER_SERVICE_FQN in response.services, (
+            f"services missing {PROVIDER_SERVICE_FQN}: {list(response.services)}"
+        )
         assert SYSTEM_SERVICE_FQN in response.services, (
             f"services missing {SYSTEM_SERVICE_FQN}: {list(response.services)}"
         )
         assert response.sdk_version == __version__
         assert response.sdk_ecosystem == system_pb2.SDK_ECOSYSTEM_PYTHON
         assert response.current_time is not None
+        skew = abs(time.time() - response.current_time.seconds)
+        assert skew < 5, f"currentTime skew = {skew}s"
+    finally:
+        server.should_exit = True
+        await server_task
+
+
+@pytest.mark.asyncio
+async def test_system_service_rejects_unsigned_request():
+    """Auto-registered SystemService inherits the signature middleware:
+    an unsigned request is rejected with INVALID_ARGUMENT (Go parity:
+    connect.CodeInvalidArgument)."""
+    _, public_key_hex = _new_keypair()
+    port = _find_free_port()
+
+    # Customer service not needed — the unsigned request never reaches a service handler.
+    app = new_asgi_app(public_key_hex)
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    server_task = asyncio.create_task(server.serve())
+    try:
+        await _wait_for_port(port)
+
+        # Plain (no signing transport) client — missing X-Public-Key header.
+        plain_client = SystemServiceClient(f"http://127.0.0.1:{port}")
+
+        with pytest.raises(ConnectError) as exc_info:
+            await plain_client.health(system_pb2.HealthRequest())
+
+        assert exc_info.value.code == Code.INVALID_ARGUMENT
     finally:
         server.should_exit = True
         await server_task


### PR DESCRIPTION
## Summary

Closes the test-coverage gap tracked by `docs/SYSTEM_SERVICE.md` ("Node, Python, Java: existing test suites build green; **no Health-specific tests yet**"). Each of those three SDKs now has the Go-canonical three-test coverage of `tzero.v1.system.SystemService.Health()`:

1. **Direct impl response shape** — `services`, `sdkVersion` / `sdk_version`, ecosystem identifier, fresh `currentTime` / `current_time`.
2. **Signed end-to-end** — through each SDK's public server-construction wrapper (`createService` for Node, `new_asgi_app` for Python, `ProviderServer.Builder.buildGrpcServer` for Java). Each test registers a stub customer `ProviderService` and asserts BOTH the customer FQN AND `tzero.v1.system.SystemService` appear in `services`.
3. **Unsigned rejected** — each language asserts the ecosystem equivalent of Go's `connect.CodeInvalidArgument` (`Code.InvalidArgument` for Node/Python, `Status.Code.INVALID_ARGUMENT` for Java), proving the signature middleware also covers the auto-registered service.

## Per-language details

- **Java**: new `network.t0.sdk.provider.SystemServiceImplTest` (same package as the impl, so it can exercise the package-private class directly via `StreamObserver` capture — no mirror class). Existing `SystemServiceIntegrationTest` left untouched (complementary angles).
- **Node**: augments the existing `node/sdk/test/system.test.ts` from PR #90. Adds an `unimplementedProviderService` stub, threads a `register` callback through `bootServer`, registers the stub in test 2, asserts both `ProviderService.typeName` AND `SystemService.typeName`, plus `<5s` freshness.
- **Python**: augments the existing `test_system_signed.py` — registers a `_StubProviderService` via `handler(ProviderServiceASGIApplication, ...)`, asserts both FQNs and 5s freshness. Adds a new `test_system_service_rejects_unsigned_request`.

Plus: `docs/SYSTEM_SERVICE.md` now lists each language's test file and removes the "no Health-specific tests yet" paragraph. Stale `python/uv.lock` regenerated (was pinned to 1.1.14 from before Release 1.1.15).

Stacked on top of #95 (C# Health tests).

## Test plan

- [x] `cd node/sdk && npm ci && npm run build && npm test` — 26 / 26 pass (3 SystemService tests included)
- [x] `cd python && uv sync --all-packages && uv run pytest -v` — 100 passed, 16 skipped (cross-tests; pre-existing)
- [x] `cd java && ./gradlew build test` — BUILD SUCCESSFUL; new SystemServiceImplTest 3 / 3 pass (verified via `sdk/build/test-results/test/TEST-network.t0.sdk.provider.SystemServiceImplTest.xml`)
- [ ] CI: per-SDK build/test jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)