### PR TITLE
chore(deps): bump @noble/curves and @noble/hashes to 2.2.0

### DIFF
--- a/node/sdk/package-lock.json
+++ b/node/sdk/package-lock.json
@@ -14,8 +14,8 @@
         "@connectrpc/connect-node": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
         "@connectrpc/validate": "^0.2.0",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1"
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0"
       },
       "devDependencies": {
         "@bufbuild/protoc-gen-es": "^2.11.0",
@@ -601,12 +601,12 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
-      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.0.1"
+        "@noble/hashes": "2.2.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -616,9 +616,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"

--- a/node/sdk/package.json
+++ b/node/sdk/package.json
@@ -34,8 +34,8 @@
     "@connectrpc/connect-node": "^2.1.1",
     "@connectrpc/connect-web": "^2.1.1",
     "@connectrpc/validate": "^0.2.0",
-    "@noble/curves": "^2.0.1",
-    "@noble/hashes": "^2.0.1"
+    "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0"
   },
   "devDependencies": {
     "@bufbuild/protoc-gen-es": "^2.11.0",

--- a/node/sdk/test/crypto.test.ts
+++ b/node/sdk/test/crypto.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, assert } from 'node:test';
 import * as nodeAssert from 'node:assert/strict';
 import { keccak_256 } from '@noble/hashes/sha3.js';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { CreateSigner } from '../src/client/signer.js';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -16,6 +17,90 @@ describe('Keccak-256 hashing', () => {
       nodeAssert.equal(hash, vec.hash);
     });
   }
+
+  // Mirrors the streaming pattern in src/service/node.ts where the
+  // signatureValidation middleware feeds N request chunks into hasher.update().
+  // Asserts incremental hashing across many chunk boundaries matches the
+  // one-shot digest, guarding against a regression in noble-hashes' sha3
+  // streaming state across releases (the 2.2.0 sha3 unrolling speedup is the
+  // exact kind of change this catches).
+  it('multi-chunk streaming digest matches one-shot for same bytes', () => {
+    const full = Buffer.from('the quick brown fox jumps over the lazy dog 0123456789', 'utf-8');
+    const oneShot = Buffer.from(keccak_256(full)).toString('hex');
+
+    for (const splits of [
+      [1, 2, 3, 4, 5],
+      [10, 20, 30],
+      [0, full.length],
+      [1, 1, 1, 1, 1, 1, 1, 1],
+    ]) {
+      const hasher = keccak_256.create();
+      let offset = 0;
+      for (const len of splits) {
+        hasher.update(full.subarray(offset, offset + len));
+        offset += len;
+      }
+      hasher.update(full.subarray(offset));
+      const streamed = Buffer.from(hasher.digest()).toString('hex');
+      nodeAssert.equal(streamed, oneShot, `splits=${splits.join(',')}`);
+    }
+  });
+});
+
+describe('secp256k1 verification', () => {
+  // service.ts line ~40 calls secp256k1.verify(signature, hash, publicKey, {prehash: false})
+  // to authenticate every inbound request. Without a direct test, regressions in
+  // noble-curves' verify path would only surface through the end-to-end Health
+  // test in system.test.ts — and only on the rejection branch we exercise there.
+  // These cases pin down the function's contract on the exact arguments the SDK
+  // hands it.
+
+  const publicKey = Buffer.from(vectors.keys.public_key, 'hex');
+  const validHash = Buffer.from(vectors.request_signing.expected_hash, 'hex');
+  const validSig = Buffer.from(vectors.request_signing.expected_signature, 'hex');
+
+  it('accepts cross-language signature against matching public key + hash', () => {
+    const ok = secp256k1.verify(validSig, validHash, publicKey, { prehash: false });
+    nodeAssert.equal(ok, true);
+  });
+
+  it('rejects signature with one bit flipped', () => {
+    const tampered = Buffer.from(validSig);
+    tampered[63] ^= 0x01;
+    const ok = secp256k1.verify(tampered, validHash, publicKey, { prehash: false });
+    nodeAssert.equal(ok, false);
+  });
+
+  it('rejects when hash does not match what was signed', () => {
+    const tamperedHash = Buffer.from(validHash);
+    tamperedHash[0] ^= 0xff;
+    const ok = secp256k1.verify(validSig, tamperedHash, publicKey, { prehash: false });
+    nodeAssert.equal(ok, false);
+  });
+
+  it('rejects against a different public key', () => {
+    // Derive a second uncompressed public key from a known good private key.
+    const otherPriv = Buffer.alloc(32);
+    otherPriv[31] = 0x01;
+    const otherPub = Buffer.from(secp256k1.getPublicKey(otherPriv, false));
+    nodeAssert.notEqual(otherPub.toString('hex'), publicKey.toString('hex'));
+
+    const ok = secp256k1.verify(validSig, validHash, otherPub, { prehash: false });
+    nodeAssert.equal(ok, false);
+  });
+
+  // SDK callers may submit a 65-byte (r||s||recoveryId) signature; service.ts
+  // truncates to the first 64 bytes before calling verify(). Asserts noble's
+  // 64-byte verify succeeds on bytes that were sliced out of a 65-byte buffer
+  // — i.e. the slice path leaves the signature byte-identical.
+  it('verifies signature sliced from a synthetic 65-byte buffer', () => {
+    const sig65 = Buffer.alloc(65);
+    validSig.copy(sig65, 0);
+    sig65[64] = 0x01; // recovery id; will be discarded
+    const truncated = sig65.subarray(0, 64);
+    const ok = secp256k1.verify(truncated, validHash, publicKey, { prehash: false });
+    nodeAssert.equal(ok, true);
+  });
 });
 
 describe('CreateSigner', () => {


### PR DESCRIPTION
## Summary

- Bumps `@noble/curves` 2.0.1 → 2.2.0 and `@noble/hashes` 2.0.1 → 2.2.0 in `/node/sdk`.
- Adds direct unit tests for every noble function the SDK calls before bumping, so the bump is provably safe rather than relying on indirect end-to-end coverage.
- All 32 SDK tests pass on both 2.0.1 and 2.2.0; the cross-language `request_signing` signature vector matches byte-for-byte on the new versions.

## Supersedes

- #65 — `@noble/curves` 2.0.1 → 2.2.0
- #67 — `@noble/hashes` 2.0.1 → 2.2.0

These were explicitly held out of the #98 batch under _"Crypto signing path"_ because they sit on the sign/verify hot path. This PR clears that bar.

## Pre-bump call-site audit

| Noble function | Used in | Direct test on 2.0.1 before this PR |
| --- | --- | --- |
| `secp256k1.getPublicKey(privKey, false)` | `src/client/signer.ts` | ✅ `crypto.test.ts` (`derives the correct public key`) |
| `secp256k1.sign(hash, privKey, {prehash:false})` | `src/client/signer.ts` | ✅ `crypto.test.ts` (cross-lang signature vector) |
| `secp256k1.utils.isValidSecretKey(...)` | `src/client/signer.ts` | ✅ `crypto.test.ts` (rejects invalid private key) |
| `secp256k1.verify(sig, hash, pubKey, {prehash:false})` | `src/service/service.ts` | ⚠️ only via end-to-end signed Health call |
| `keccak_256(input)` (one-shot) | tests | ✅ 3 vectors |
| `keccak_256.create()` + 2× `.update()` + `.digest()` | `src/client/client.ts` | ✅ `request_signing` vector |
| `keccak_256.create()` + N>2 chunked `.update()` | `src/service/node.ts` (HTTP middleware) | ❌ not covered |

## Test additions

In `node/sdk/test/crypto.test.ts`:

- `secp256k1 verification` suite — direct `secp256k1.verify` on the cross-language vector. Positive case + three independent rejection cases (one-bit-flipped signature, tampered hash, mismatched public key) + a 65-byte→64-byte truncation case mirroring the slice in `src/service/service.ts`.
- `Keccak-256 hashing > multi-chunk streaming digest matches one-shot for same bytes` — feeds the same input through `keccak_256.create()` across four different chunk-boundary patterns and asserts every digest equals the one-shot result. Pinned specifically because 2.2.0's sha3 unrolling speedup is the kind of change that would slip past the existing 2-chunk vector.

The new tests pass against both 2.0.1 (proving they encode the existing contract) and 2.2.0 (proving the bump preserves it).

## Crypto safety attestation

- The cross-language `request_signing` signature vector in `cross_test/test_vectors.json` continues to verify byte-identically against `@noble/curves@2.2.0`. This is the canonical proof that signing output is unchanged across the bump.
- The new direct `secp256k1.verify` cases pin the verifier's contract independent of the HTTP path.
- Per `CLAUDE.md`: signature verification continues to use raw payload bytes; nothing in this PR touches that.

## Test plan

- [x] `cd node/sdk && npm ci && npm run build && npm test` on 2.0.1 baseline → 26/26 green
- [x] Add 6 new tests, re-run on 2.0.1 → 32/32 green
- [x] `npm install` to bump to 2.2.0, clean rebuild, re-run → 32/32 green
- [ ] CI re-runs the above on the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)