### PR TITLE
chore(java): bump bouncycastle 1.83→1.84 with expanded BC test coverage

### DIFF
--- a/java/sdk/build.gradle.kts
+++ b/java/sdk/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 val grpcVersion = "1.81.0"
 val protobufVersion = "4.34.1"
-val bouncyCastleVersion = "1.83"
+val bouncyCastleVersion = "1.84"
 
 dependencies {
     // gRPC dependencies

--- a/java/sdk/src/test/java/network/t0/sdk/crypto/SignatureVerifierTest.java
+++ b/java/sdk/src/test/java/network/t0/sdk/crypto/SignatureVerifierTest.java
@@ -2,6 +2,9 @@ package network.t0.sdk.crypto;
 
 import org.junit.jupiter.api.Test;
 
+import java.math.BigInteger;
+import java.util.Arrays;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -229,6 +232,144 @@ class SignatureVerifierTest {
     void publicKeysEqual_nullSecond_shouldReturnFalse() {
         byte[] key = hexToBytes(PUBLIC_KEY_HEX);
         assertThat(SignatureVerifier.publicKeysEqual(key, null)).isFalse();
+    }
+
+    // ==================== BC ECCurve.decodePoint exception path ====================
+    // SignatureVerifier wraps decodePoint in try/catch(IllegalArgumentException);
+    // these tests pass 65-byte buffers that BC must reject so the catch returns false.
+
+    @Test
+    void verify_offCurvePublicKey_shouldReturnFalse() {
+        // 0x04 prefix with x=1, y=1 - not on secp256k1 (y^2 = x^3 + 7 mod p).
+        byte[] offCurveKey = new byte[65];
+        offCurveKey[0] = 0x04;
+        offCurveKey[32] = 0x01; // x = 1
+        offCurveKey[64] = 0x01; // y = 1
+
+        Signer signer = Signer.fromHex(PRIVATE_KEY_HEX);
+        byte[] digest = hexToBytes(MESSAGE_KECCAK_HASH);
+        SignResult sig = signer.sign(digest);
+
+        assertThat(SignatureVerifier.verify(offCurveKey, digest, sig.getSignature()))
+                .isFalse();
+    }
+
+    @Test
+    void verify_invalidPublicKeyPrefix_shouldReturnFalse() {
+        // Valid x,y but with prefix 0x05 - BC rejects unknown encoding bytes.
+        byte[] validKey = hexToBytes(PUBLIC_KEY_HEX);
+        byte[] invalidPrefixKey = Arrays.copyOf(validKey, validKey.length);
+        invalidPrefixKey[0] = 0x05;
+
+        Signer signer = Signer.fromHex(PRIVATE_KEY_HEX);
+        byte[] digest = hexToBytes(MESSAGE_KECCAK_HASH);
+        SignResult sig = signer.sign(digest);
+
+        assertThat(SignatureVerifier.verify(invalidPrefixKey, digest, sig.getSignature()))
+                .isFalse();
+    }
+
+    @Test
+    void verify_allZeroPublicKey_shouldReturnFalse() {
+        byte[] zeroKey = new byte[65];
+
+        Signer signer = Signer.fromHex(PRIVATE_KEY_HEX);
+        byte[] digest = hexToBytes(MESSAGE_KECCAK_HASH);
+        SignResult sig = signer.sign(digest);
+
+        assertThat(SignatureVerifier.verify(zeroKey, digest, sig.getSignature()))
+                .isFalse();
+    }
+
+    // ==================== BC ECDSASigner range-check coverage ====================
+    // ECDSASigner.verifySignature must reject r/s = 0 and r/s >= n per the ECDSA spec.
+
+    @Test
+    void verify_zeroR_shouldReturnFalse() {
+        byte[] sigZeroR = new byte[65];
+        sigZeroR[63] = 0x01; // s = 1, r = 0
+
+        Signer signer = Signer.fromHex(PRIVATE_KEY_HEX);
+        byte[] digest = hexToBytes(MESSAGE_KECCAK_HASH);
+
+        assertThat(SignatureVerifier.verify(signer.getPublicKey(), digest, sigZeroR))
+                .isFalse();
+    }
+
+    @Test
+    void verify_zeroS_shouldReturnFalse() {
+        byte[] sigZeroS = new byte[65];
+        sigZeroS[31] = 0x01; // r = 1, s = 0
+
+        Signer signer = Signer.fromHex(PRIVATE_KEY_HEX);
+        byte[] digest = hexToBytes(MESSAGE_KECCAK_HASH);
+
+        assertThat(SignatureVerifier.verify(signer.getPublicKey(), digest, sigZeroS))
+                .isFalse();
+    }
+
+    @Test
+    void verify_rEqualToCurveOrder_shouldReturnFalse() {
+        byte[] nBytes = hexToBytes("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+        byte[] sig = new byte[65];
+        System.arraycopy(nBytes, 0, sig, 0, 32); // r = n
+        sig[63] = 0x01; // s = 1
+
+        Signer signer = Signer.fromHex(PRIVATE_KEY_HEX);
+        byte[] digest = hexToBytes(MESSAGE_KECCAK_HASH);
+
+        assertThat(SignatureVerifier.verify(signer.getPublicKey(), digest, sig))
+                .isFalse();
+    }
+
+    @Test
+    void verify_sEqualToCurveOrder_shouldReturnFalse() {
+        byte[] nBytes = hexToBytes("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+        byte[] sig = new byte[65];
+        sig[31] = 0x01; // r = 1
+        System.arraycopy(nBytes, 0, sig, 32, 32); // s = n
+
+        Signer signer = Signer.fromHex(PRIVATE_KEY_HEX);
+        byte[] digest = hexToBytes(MESSAGE_KECCAK_HASH);
+
+        assertThat(SignatureVerifier.verify(signer.getPublicKey(), digest, sig))
+                .isFalse();
+    }
+
+    // ==================== High-s signature acceptance (BC behavior lock-in) ====================
+    // BC's ECDSASigner.verifySignature accepts both low-s and high-s forms (s and n - s
+    // are mathematically equivalent ECDSA signatures). Signer.sign normalizes to low-s,
+    // but the verifier must still accept externally-produced high-s signatures.
+
+    @Test
+    void verify_acceptsHighSSignature() {
+        Signer signer = Signer.fromHex(PRIVATE_KEY_HEX);
+        byte[] digest = hexToBytes(MESSAGE_KECCAK_HASH);
+        SignResult result = signer.sign(digest);
+
+        BigInteger n = new BigInteger(
+                "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16);
+        BigInteger lowS = new BigInteger(1, result.getS());
+        BigInteger highS = n.subtract(lowS);
+
+        byte[] highSSig = new byte[65];
+        System.arraycopy(result.getR(), 0, highSSig, 0, 32);
+        System.arraycopy(bigIntegerTo32Bytes(highS), 0, highSSig, 32, 32);
+        // v left at 0 (verify ignores it)
+
+        assertThat(SignatureVerifier.verify(signer.getPublicKey(), digest, highSSig))
+                .isTrue();
+    }
+
+    private static byte[] bigIntegerTo32Bytes(BigInteger value) {
+        byte[] raw = value.toByteArray();
+        if (raw.length == 32) return raw;
+        if (raw.length > 32) {
+            return Arrays.copyOfRange(raw, raw.length - 32, raw.length);
+        }
+        byte[] padded = new byte[32];
+        System.arraycopy(raw, 0, padded, 32 - raw.length, raw.length);
+        return padded;
     }
 
     private static byte[] hexToBytes(String hex) {

--- a/java/sdk/src/test/java/network/t0/sdk/crypto/SignerTest.java
+++ b/java/sdk/src/test/java/network/t0/sdk/crypto/SignerTest.java
@@ -2,6 +2,8 @@ package network.t0.sdk.crypto;
 
 import org.junit.jupiter.api.Test;
 
+import java.math.BigInteger;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -196,6 +198,122 @@ class SignerTest {
         assertThatThrownBy(() -> signer.sign(null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("digest must be 32 bytes");
+    }
+
+    // ==================== fromBytes Tests ====================
+    // fromBytes is part of the public API (used by cli/KeyGenerator and the starter
+    // gradle task) and exercises the same BouncyCastle paths as fromHex
+    // (FixedPointCombMultiplier, ECPoint.getEncoded, CustomNamedCurves).
+
+    @Test
+    void fromBytes_shouldDeriveCorrectPublicKey() {
+        byte[] privateKeyBytes = hexToBytes(PRIVATE_KEY_HEX);
+        Signer signer = Signer.fromBytes(privateKeyBytes);
+
+        assertThat(signer.getPublicKeyHex()).isEqualTo(EXPECTED_PUBLIC_KEY_HEX);
+    }
+
+    @Test
+    void fromBytes_shouldMatchFromHex() {
+        byte[] privateKeyBytes = hexToBytes(PRIVATE_KEY_HEX);
+        Signer signerFromBytes = Signer.fromBytes(privateKeyBytes);
+        Signer signerFromHex = Signer.fromHex(PRIVATE_KEY_HEX);
+
+        assertThat(signerFromBytes.getPublicKey()).isEqualTo(signerFromHex.getPublicKey());
+    }
+
+    @Test
+    void fromBytes_signatureMatchesFromHex() {
+        byte[] privateKeyBytes = hexToBytes(PRIVATE_KEY_HEX);
+        byte[] digest = hexToBytes(MESSAGE_KECCAK_HASH);
+
+        SignResult fromBytesResult = Signer.fromBytes(privateKeyBytes).sign(digest);
+        SignResult fromHexResult = Signer.fromHex(PRIVATE_KEY_HEX).sign(digest);
+
+        assertThat(fromBytesResult.getSignature()).isEqualTo(fromHexResult.getSignature());
+    }
+
+    @Test
+    void fromBytes_null_shouldThrow() {
+        assertThatThrownBy(() -> Signer.fromBytes(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("private key must be 32 bytes");
+    }
+
+    @Test
+    void fromBytes_wrongLengthShort_shouldThrow() {
+        assertThatThrownBy(() -> Signer.fromBytes(new byte[31]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("private key must be 32 bytes");
+    }
+
+    @Test
+    void fromBytes_wrongLengthLong_shouldThrow() {
+        assertThatThrownBy(() -> Signer.fromBytes(new byte[33]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("private key must be 32 bytes");
+    }
+
+    @Test
+    void fromBytes_zeroKey_shouldThrow() {
+        assertThatThrownBy(() -> Signer.fromBytes(new byte[32]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("private key must be in range [1, n-1]");
+    }
+
+    @Test
+    void fromBytes_keyAtCurveOrder_shouldThrow() {
+        byte[] keyAtN = hexToBytes("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+        assertThatThrownBy(() -> Signer.fromBytes(keyAtN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("private key must be in range [1, n-1]");
+    }
+
+    // ==================== Canonical (low-s) Signature ====================
+    // BouncyCastle's ECDSASigner.generateSignature can produce either low-s or high-s;
+    // Signer.sign normalizes to the canonical low-s form (s <= n/2). Lock the behavior
+    // in across many distinct digests so a BC change that drops the normalization is caught.
+
+    @Test
+    void sign_producesLowSCanonicalSignature() {
+        Signer signer = Signer.fromHex(PRIVATE_KEY_HEX);
+        BigInteger n = new BigInteger(
+                "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16);
+        BigInteger halfN = n.shiftRight(1);
+
+        for (int i = 0; i < 32; i++) {
+            byte[] digest = Keccak256.hash(("low-s test " + i).getBytes());
+            SignResult result = signer.sign(digest);
+
+            BigInteger s = new BigInteger(1, result.getS());
+            assertThat(s)
+                    .as("signature %d must have s <= n/2 (canonical low-s)", i)
+                    .isLessThanOrEqualTo(halfN);
+        }
+    }
+
+    // ==================== Recovery ID Both Branches ====================
+    // calculateRecoveryId / recoverPublicKey iterate recId 0 and 1, exercising BC's
+    // ECCurve.decodePoint, ECPoint.multiply/subtract/isInfinity, ECPoint.getEncoded.
+    // RFC 6979 makes individual signatures deterministic but the v split is ~50/50
+    // across distinct digests; scan until both branches fire.
+
+    @Test
+    void sign_exercisesBothRecoveryIds() {
+        Signer signer = Signer.fromHex(PRIVATE_KEY_HEX);
+        boolean sawV0 = false;
+        boolean sawV1 = false;
+
+        for (int i = 0; i < 64 && !(sawV0 && sawV1); i++) {
+            byte[] digest = Keccak256.hash(("recid test " + i).getBytes());
+            int v = signer.sign(digest).getV();
+            if (v == 0) sawV0 = true;
+            else if (v == 1) sawV1 = true;
+            else throw new AssertionError("unexpected recovery id: " + v);
+        }
+
+        assertThat(sawV0).as("recovery id 0 must occur within 64 digests").isTrue();
+        assertThat(sawV1).as("recovery id 1 must occur within 64 digests").isTrue();
     }
 
     private static String bytesToHex(byte[] bytes) {


### PR DESCRIPTION
## Summary

Supersedes dependabot PR #60.

- Bumps `org.bouncycastle:bcprov-jdk18on` from **1.83 → 1.84** in `java/sdk/build.gradle.kts`.
- Adds **18 tests** that exercise BouncyCastle code paths that were unverified by the existing suite, so any future BC bump (or this one) has a concrete failure mode if a behavior changes.

## What was uncovered before

Audited `sdk/src/main/java/network/t0/sdk/crypto/{Keccak256,Signer,SignatureVerifier}.java` against existing tests. `Keccak256` was well-covered. The gaps in `Signer` and `SignatureVerifier`:

| Gap | New tests |
| --- | --- |
| `Signer.fromBytes(byte[])` (public API used by `cli/KeyGenerator` and the starter `generateKeys` Gradle task) had **zero** direct tests | 7 in `SignerTest` |
| Canonical low-s normalization in `Signer.sign` was implicit, never asserted | 1 in `SignerTest` |
| Both recovery-id branches (v=0 / v=1) of `calculateRecoveryId` were not pinned (assertion was `isIn(0, 1)`, tautological) | 1 in `SignerTest` |
| `SignatureVerifier.verify` rejection of off-curve / invalid-prefix / all-zero public keys (BC `ECCurve.decodePoint` exception path) | 3 in `SignatureVerifierTest` |
| `SignatureVerifier.verify` rejection of r=0, s=0, r=n, s=n (BC `ECDSASigner.verifySignature` range checks) | 4 in `SignatureVerifierTest` |
| BC verifier accepting both low-s and high-s forms of a signature (lock-in test) | 1 in `SignatureVerifierTest` |

## Test plan

- [x] Run `./gradlew :sdk:test` on baseline `bcprov-jdk18on:1.83` with new tests added → 157 tests, 0 failures.
- [x] Bump to `bcprov-jdk18on:1.84` and re-run `./gradlew :sdk:test` → 157 tests, 0 failures.
- [x] Run `./gradlew :sdk:build` on 1.84 → success (jar / sourcesJar / javadocJar all produced).
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)