### PR TITLE
fix(ci): order and make idempotent release tag/release creation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -310,6 +310,15 @@ jobs:
     # 2vcpu is sufficient — most time is spent polling Maven Central for deployment status
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: provider-sdk
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -351,10 +360,15 @@ jobs:
           MAVEN_CENTRAL_USERNAME: ${{ vars.OSSRH_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
+      # Runs even if "Publish to Maven Central" failed — e.g. the version was already
+      # published in a prior/duplicate deployment (Central rejects re-publishing an existing
+      # version). The CLI jar must still reach the GitHub Release regardless. Uses the App
+      # token, not GITHUB_TOKEN, which the releases API now rejects (same fix as release.yaml).
       - name: Upload provider-init.jar to GitHub Release
+        if: ${{ !cancelled() }}
         working-directory: java
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           cp cli/build/libs/provider-init-${VERSION}.jar cli/build/libs/provider-init.jar

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -359,25 +359,59 @@ jobs:
           fi
           echo "All version validations passed for $VERSION"
 
-      # --- Commit and tag ---
+      # --- Commit, tag, and release ---
+      # Ordering is load-bearing. publish.yaml is triggered by the `v<version>` tag, and its
+      # "Publish Go" job asks the Go module proxy to resolve `.../go@v<version>`, which the
+      # proxy maps to the `go/v<version>` tag. So the go/* tags MUST already be on the remote
+      # before the `v<version>` tag is pushed, otherwise Publish Go races ahead and 404s (this
+      # is what broke 1.1.20). We push the go/* tags first and the trigger tag last.
+      #
+      # Every step here is idempotent (create-if-absent). A re-run of a partially-failed
+      # release recomputes the SAME version (the new tags aren't reachable from the re-run's
+      # checkout of the pre-release commit), so it must not hard-fail on already-existing tags
+      # or release — the 1.1.20 re-run died on `fatal: tag 'v1.1.20' already exists`.
       - name: Commit version bump
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "Release ${{ steps.version.outputs.version }}"
-          tagging_message: "v${{ steps.version.outputs.version }}"
+          # No tagging_message: the v<version> tag is pushed explicitly below, AFTER the
+          # go/* tags, so it is the last ref pushed (it is what triggers publish.yaml).
 
-      - name: Create GitHub Release
-        uses: elgohr/Github-Release-Action@v5
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          title: ${{ steps.version.outputs.version }}
-          tag: v${{ steps.version.outputs.version }}
-
-      - name: Create Go module tags
+      - name: Push Go module tags
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          git tag "go/v${VERSION}"
-          git tag "go/starter/v${VERSION}"
-          git tag "go/starter/template/v${VERSION}"
-          git push origin "go/v${VERSION}" "go/starter/v${VERSION}" "go/starter/template/v${VERSION}"
+          for t in "go/v${VERSION}" "go/starter/v${VERSION}" "go/starter/template/v${VERSION}"; do
+            if git ls-remote --exit-code origin "refs/tags/${t}" >/dev/null 2>&1; then
+              echo "Tag ${t} already exists on origin — skipping"
+            else
+              git tag "${t}"
+              git push origin "${t}"
+            fi
+          done
+
+      - name: Push release tag (triggers publish.yaml)
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if git ls-remote --exit-code origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists on origin — skipping"
+          else
+            git tag -a "v${VERSION}" -m "v${VERSION}"
+            git push origin "v${VERSION}"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          # Use the GitHub App token (same token the pushes above use), NOT the default
+          # GITHUB_TOKEN — the default token started returning HTTP 401 from the releases API
+          # and silently broke the 1.1.20 release. The App token carries the contents:write
+          # needed to create releases, and `gh release view` makes this step idempotent
+          # (the previous third-party action was not).
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if gh release view "v${VERSION}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release v${VERSION} already exists — skipping"
+          else
+            gh release create "v${VERSION}" --repo "${{ github.repository }}" \
+              --title "${VERSION}" --notes "Release ${VERSION}"
+          fi


### PR DESCRIPTION
## Problem

The 1.1.20 release left a half-published state — the `v1.1.20` tag was pushed (which triggers `publish.yaml`) but the `go/*` module tags were never created, so **Publish Go** 404'd resolving `go@v1.1.20` from the Go module proxy.

Failing publish run: https://github.com/t-0-network/provider-sdk/actions/runs/27287362351

### Root cause — release run [27287245103](https://github.com/t-0-network/provider-sdk/actions/runs/27287245103) (2 attempts)
- **Attempt 1** pushed `v1.1.20` (commit + tag), then **`Create GitHub Release` failed with `HTTP 401`** — the default `GITHUB_TOKEN` is now rejected by the releases API. The final `Create Go module tags` step was skipped.
- **Attempt 2** (re-run) hard-failed earlier at `Commit version bump`: `fatal: tag 'v1.1.20' already exists`.

So `Create Go module tags` never ran in either attempt → the `go/*` tags were missing → the Go proxy could not resolve the module.

## Fix (`release.yaml`)
1. **App token for the release step** — use `steps.app-token.outputs.token` (the same token the git pushes already use) instead of the 401-ing `GITHUB_TOKEN`; replace the third-party `elgohr/Github-Release-Action@v5` with `gh release create`.
2. **Tag ordering** — push the `go/*` tags **before** the `v<version>` trigger tag, so Publish Go cannot outrun them (also closes a latent race that existed even on success).
3. **Idempotency** — every tag/release operation is now create-if-absent, so a re-run of a partially-failed release recovers instead of aborting on "tag already exists".

## Notes
- The already-broken 1.1.20 state was remediated out-of-band: the three `go/*` tags were pushed (Go 1.1.20 now resolves on the proxy) and the missing `v1.1.20` GitHub Release was created.
- Statically validated (YAML parses); the change's first real exercise will be the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
