### PR TITLE
fix(ci): simplify release tagging + move Go module tags into Publish Go

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -165,9 +165,9 @@ jobs:
           echo "Go SDK runtime version $RUNTIME matches tag v$VERSION"
 
       # Create the go/* module tags here, right before warming the proxy, so the proxy is never
-      # asked to resolve a version before its tag exists (the gap that 404'd Go on 1.1.20, and
-      # whose negative cache then lingered). Lightweight tags need no git identity; re-running
-      # this job is safe — re-pushing an identical tag is a no-op.
+      # asked to resolve a version before its tag exists (otherwise it negative-caches the 404).
+      # Lightweight tags need no git identity; re-running this job is safe — re-pushing an
+      # identical tag is a no-op.
       - name: Create and push Go module tags
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -176,12 +176,25 @@ jobs:
           git tag "go/starter/template/v${VERSION}"
           git push origin "go/v${VERSION}" "go/starter/v${VERSION}" "go/starter/template/v${VERSION}"
 
+      # A freshly pushed tag can take a moment to become visible to proxy.golang.org, so retry
+      # each module a few times before failing.
       - name: Request GOPROXY update
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
-          GOPROXY=proxy.golang.org go list -m "github.com/t-0-network/provider-sdk/go@v${VERSION}"
-          GOPROXY=proxy.golang.org go list -m "github.com/t-0-network/provider-sdk/go/starter@v${VERSION}"
-          GOPROXY=proxy.golang.org go list -m "github.com/t-0-network/provider-sdk/go/starter/template@v${VERSION}"
+          warm() {
+            for attempt in 1 2 3 4 5; do
+              if GOPROXY=proxy.golang.org go list -m "$1@v${VERSION}"; then
+                return 0
+              fi
+              echo "proxy not ready for $1@v${VERSION} (attempt ${attempt}/5); retrying in 10s..."
+              sleep 10
+            done
+            echo "::error::proxy.golang.org did not serve $1@v${VERSION} after 5 attempts"
+            return 1
+          }
+          warm "github.com/t-0-network/provider-sdk/go"
+          warm "github.com/t-0-network/provider-sdk/go/starter"
+          warm "github.com/t-0-network/provider-sdk/go/starter/template"
 
   publish-node-sdk:
     name: Publish Node SDK

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -135,9 +135,20 @@ jobs:
     needs: [build-go, build-node, build-java, build-python, build-csharp]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: provider-sdk
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          # App token so the `git push` of the module tags below is authenticated.
+          token: ${{ steps.app-token.outputs.token }}
           show-progress: false
 
       - name: Setup Go
@@ -152,6 +163,18 @@ jobs:
           RUNTIME=$(grep 'const Version = ' go/sdkversion/version.go | sed 's/.*"\(.*\)".*/\1/')
           [ "$RUNTIME" = "$VERSION" ] || { echo "::error::go/sdkversion/version.go has $RUNTIME, tag is v$VERSION"; exit 1; }
           echo "Go SDK runtime version $RUNTIME matches tag v$VERSION"
+
+      # Create the go/* module tags here, right before warming the proxy, so the proxy is never
+      # asked to resolve a version before its tag exists (the gap that 404'd Go on 1.1.20, and
+      # whose negative cache then lingered). Lightweight tags need no git identity; re-running
+      # this job is safe — re-pushing an identical tag is a no-op.
+      - name: Create and push Go module tags
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          git tag "go/v${VERSION}"
+          git tag "go/starter/v${VERSION}"
+          git tag "go/starter/template/v${VERSION}"
+          git push origin "go/v${VERSION}" "go/starter/v${VERSION}" "go/starter/template/v${VERSION}"
 
       - name: Request GOPROXY update
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -362,11 +362,13 @@ jobs:
       # --- Commit, tag, and release ---
       # git-auto-commit-action commits the version bump and pushes the v<version> tag (as the
       # github-actions bot — it sets its own identity), which triggers publish.yaml. We then
-      # create the GitHub Release for that tag with `gh` + the App token. The App token is the
-      # one real fix over the previous setup: the default GITHUB_TOKEN started getting HTTP 401
-      # from the releases API (it worked through 1.1.19, broke at 1.1.20). Finally we push the
-      # go/* module tags that the Go proxy resolves — there is no GitHub-release equivalent for
-      # those, so they have to be plain git tags.
+      # create the GitHub Release for that tag with `gh` + the App token — NOT the default
+      # GITHUB_TOKEN, which the releases API now rejects with HTTP 401 (it worked through 1.1.19,
+      # broke at 1.1.20).
+      #
+      # The go/* Go module tags are NOT created here. They live in publish.yaml's "Publish Go"
+      # job, created right before it warms the Go proxy — so the proxy is never asked to resolve
+      # a version before its tag exists (that ordering gap is what 404'd Go on 1.1.20).
       - name: Commit version bump
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
@@ -381,11 +383,3 @@ jobs:
             --verify-tag \
             --title "${{ steps.version.outputs.version }}" \
             --notes "Release ${{ steps.version.outputs.version }}"
-
-      - name: Create Go module tags
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          git tag "go/v${VERSION}"
-          git tag "go/starter/v${VERSION}"
-          git tag "go/starter/template/v${VERSION}"
-          git push origin "go/v${VERSION}" "go/starter/v${VERSION}" "go/starter/template/v${VERSION}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -363,12 +363,11 @@ jobs:
       # git-auto-commit-action commits the version bump and pushes the v<version> tag (as the
       # github-actions bot — it sets its own identity), which triggers publish.yaml. We then
       # create the GitHub Release for that tag with `gh` + the App token — NOT the default
-      # GITHUB_TOKEN, which the releases API now rejects with HTTP 401 (it worked through 1.1.19,
-      # broke at 1.1.20).
+      # GITHUB_TOKEN, which the releases API rejects with HTTP 401.
       #
       # The go/* Go module tags are NOT created here. They live in publish.yaml's "Publish Go"
       # job, created right before it warms the Go proxy — so the proxy is never asked to resolve
-      # a version before its tag exists (that ordering gap is what 404'd Go on 1.1.20).
+      # a version before its tag exists.
       - name: Commit version bump
         uses: stefanzweifel/git-auto-commit-action@v7
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -360,58 +360,32 @@ jobs:
           echo "All version validations passed for $VERSION"
 
       # --- Commit, tag, and release ---
-      # Ordering is load-bearing. publish.yaml is triggered by the `v<version>` tag, and its
-      # "Publish Go" job asks the Go module proxy to resolve `.../go@v<version>`, which the
-      # proxy maps to the `go/v<version>` tag. So the go/* tags MUST already be on the remote
-      # before the `v<version>` tag is pushed, otherwise Publish Go races ahead and 404s (this
-      # is what broke 1.1.20). We push the go/* tags first and the trigger tag last.
-      #
-      # Every step here is idempotent (create-if-absent). A re-run of a partially-failed
-      # release recomputes the SAME version (the new tags aren't reachable from the re-run's
-      # checkout of the pre-release commit), so it must not hard-fail on already-existing tags
-      # or release — the 1.1.20 re-run died on `fatal: tag 'v1.1.20' already exists`.
+      # git-auto-commit-action commits the version bump and pushes the v<version> tag (as the
+      # github-actions bot — it sets its own identity), which triggers publish.yaml. We then
+      # create the GitHub Release for that tag with `gh` + the App token. The App token is the
+      # one real fix over the previous setup: the default GITHUB_TOKEN started getting HTTP 401
+      # from the releases API (it worked through 1.1.19, broke at 1.1.20). Finally we push the
+      # go/* module tags that the Go proxy resolves — there is no GitHub-release equivalent for
+      # those, so they have to be plain git tags.
       - name: Commit version bump
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "Release ${{ steps.version.outputs.version }}"
-          # No tagging_message: the v<version> tag is pushed explicitly below, AFTER the
-          # go/* tags, so it is the last ref pushed (it is what triggers publish.yaml).
-
-      - name: Push Go module tags
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          for t in "go/v${VERSION}" "go/starter/v${VERSION}" "go/starter/template/v${VERSION}"; do
-            if git ls-remote --exit-code origin "refs/tags/${t}" >/dev/null 2>&1; then
-              echo "Tag ${t} already exists on origin — skipping"
-            else
-              git tag "${t}"
-              git push origin "${t}"
-            fi
-          done
-
-      - name: Push release tag (triggers publish.yaml)
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          if git ls-remote --exit-code origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
-            echo "Tag v${VERSION} already exists on origin — skipping"
-          else
-            git tag -a "v${VERSION}" -m "v${VERSION}"
-            git push origin "v${VERSION}"
-          fi
+          tagging_message: "v${{ steps.version.outputs.version }}"
 
       - name: Create GitHub Release
         env:
-          # Use the GitHub App token (same token the pushes above use), NOT the default
-          # GITHUB_TOKEN — the default token started returning HTTP 401 from the releases API
-          # and silently broke the 1.1.20 release. The App token carries the contents:write
-          # needed to create releases, and `gh release view` makes this step idempotent
-          # (the previous third-party action was not).
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --verify-tag \
+            --title "${{ steps.version.outputs.version }}" \
+            --notes "Release ${{ steps.version.outputs.version }}"
+
+      - name: Create Go module tags
+        run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if gh release view "v${VERSION}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "Release v${VERSION} already exists — skipping"
-          else
-            gh release create "v${VERSION}" --repo "${{ github.repository }}" \
-              --title "${VERSION}" --notes "Release ${VERSION}"
-          fi
+          git tag "go/v${VERSION}"
+          git tag "go/starter/v${VERSION}"
+          git tag "go/starter/template/v${VERSION}"
+          git push origin "go/v${VERSION}" "go/starter/v${VERSION}" "go/starter/template/v${VERSION}"

--- a/docs/RELEASE_AND_PUBLISH.md
+++ b/docs/RELEASE_AND_PUBLISH.md
@@ -31,7 +31,8 @@ Triggered by `gh workflow run release.yaml -f bump=<patch|minor|major> --ref mas
    5. **Validate updated files** — re-greps every package-level, runtime-constant, and starter-template version site and confirms they all equal the calculated version. Any mismatch fails the release before tagging.
    6. **Commit and tag** — single commit `Release X.Y.Z`, root tag `vX.Y.Z`.
    7. **Create GitHub Release** — `vX.Y.Z` with that title.
-   8. **Push Go module tags** — `go/vX.Y.Z`, `go/starter/vX.Y.Z`, `go/starter/template/vX.Y.Z`. Required because Go modules version per-directory.
+
+   (The `go/*` module tags are **not** created here — they're created by `publish.yaml`'s `publish-go` job, right before it warms the proxy. See below.)
 
 3. **Tag push triggers `publish.yaml`** automatically (next section).
 
@@ -75,7 +76,7 @@ Inlined per-job (rather than as a single shared `validate-versions` job) so each
 
 | Job | Runner | Validates | Then |
 |---|---|---|---|
-| `publish-go` | blacksmith | `go/sdkversion/version.go` matches tag | `go list -m` against `proxy.golang.org` to warm the module proxy for the three Go module tags. No artifact upload — Go modules are served from the git tag itself. |
+| `publish-go` | blacksmith | `go/sdkversion/version.go` matches tag | Creates + pushes the three Go module tags (`go/vX.Y.Z`, `go/starter/vX.Y.Z`, `go/starter/template/vX.Y.Z`), then `go list -m` against `proxy.golang.org` to warm the module proxy. Tags are created here (not in `release.yaml`) so they exist before the proxy is first queried — otherwise the proxy negative-caches a 404. No artifact upload — Go modules are served from the git tag itself. |
 | `publish-node-sdk` | **`ubuntu-latest`** (npm provenance requires GitHub-hosted) | `node/sdk/src/version.ts` + `node/sdk/package.json` match tag | `npm publish --provenance --access public`. |
 | `publish-node-starter` | **`ubuntu-latest`** | `node/starter/package.json` matches tag | `npm publish --provenance --access public`. |
 | `publish-python-sdk` | blacksmith, env `pypi-sdk` | `_version.py` + `pyproject.toml` match tag | `uv build --package t0-provider-sdk` then `uv publish --trusted-publishing always`. |
@@ -104,6 +105,6 @@ Both gates are necessary and inexpensive (each is a few greps).
 ## Operating notes
 
 - **Never trigger `publish.yaml` manually.** It will refuse to publish if the tag doesn't match the runtime constants, but it will also try to actually publish to npm / PyPI / Maven Central / NuGet on success — there's no "dry run" mode.
-- **Never `git tag vX.Y.Z` by hand.** The release workflow creates the four tags in a coordinated push (`vX.Y.Z`, `go/vX.Y.Z`, `go/starter/vX.Y.Z`, `go/starter/template/vX.Y.Z`).
+- **Never `git tag vX.Y.Z` by hand.** `release.yaml` pushes the root `vX.Y.Z` tag (which triggers publish); `publish.yaml`'s `publish-go` job then creates the three `go/*` module tags. Don't create any of them manually.
 - **Re-running a failed publish job:** safe for idempotent steps (Go module proxy warm-up, JitPack verify). For npm/PyPI/Maven Central/NuGet, the registry rejects duplicate version uploads, so a re-run after a successful publish will fail loudly — that's the intended behaviour. If a publish job partially failed, fix the cause and ask the user before re-running.
 - **`provider-init.jar` upload:** `publish-java` writes the file to the existing GitHub Release with `--clobber`. The Release was created earlier by `release.yaml`.


### PR DESCRIPTION
## Why

The 1.1.21 release failed at the `Push release tag` step #150 added — `git tag -a` (annotated) needs a git identity the job never sets. Stepping back, **#150 over-corrected**: the only real cause of the 1.1.20 break was the GitHub releases API returning **HTTP 401 to the default `GITHUB_TOKEN`**. This PR strips the rework back and puts each piece where it belongs.

## Changes

### `release.yaml` — back to the simple shape, with the token fix
- Restore `tagging_message` → `git-auto-commit-action` pushes the `v<version>` tag as the bot (how releases worked through 1.1.19). No manual `git tag`, no identity step.
- `Create GitHub Release` → `gh release create --verify-tag` + the **GitHub App token** (vs. the third-party action + `GITHUB_TOKEN` that 401'd).
- Drops the `Create Go module tags` step (moved — see below).

### `publish.yaml` — Go module tags move into the `Publish Go` job
The `go/*` tags *are* the Go publish mechanism, so they now live with it — created + pushed right before `Request GOPROXY update`. This guarantees the tag exists before the proxy is ever queried, which removes the ordering gap that 404'd Go on 1.1.20 **and** the proxy negative-cache that lingered afterward. `Publish Go` gains an App-token step + token'd checkout for the push (lightweight tags → no git identity).

## Result
- `release.yaml` has zero Go-specific knowledge — just commit + tag + GitHub Release.
- Go publishing (tags + proxy warm-up) is self-contained and race-free in `publish.yaml`.
- No `git tag -a`, no identity step, no idempotency guards.

## Notes
- 1.1.21 itself was recovered out-of-band with `gh release create v1.1.21`.
- Independent infra issue, not addressed here: the 1.1.21 publish is currently blocked by a PyPI `/simple/tzdata/` outage in `Build Python`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
