### PR TITLE
fix(ci): calculate release version from vX.Y.Z tags only

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,8 +165,10 @@ jobs:
       - name: Calculate version
         id: version
         run: |
-          # Get latest tag, default to v1.1.0 if none exists
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.1.0")
+          # Latest vX.Y.Z release tag (default v1.1.0 if none). --match restricts to semver
+          # release tags so the go/* module tags — which sit on the same commits — are never
+          # picked, which would otherwise yield a garbage version like "go/.../v1.2.3".
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || echo "v1.1.0")
           CURRENT="${LATEST_TAG#v}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
 


### PR DESCRIPTION
## Why

A release run failed at `Update TS SDK version` with `npm error Invalid version: go/starter/template/v1.1.22` ([run](https://github.com/t-0-network/provider-sdk/actions/runs/27339187616)).

`Calculate version` uses `git describe --tags --abbrev=0`, which returns the nearest tag of **any** kind. The `go/*` module tags sit on the same commits as the `vX.Y.Z` release tags; once those tags are all lightweight, `git describe` picked `go/starter/template/v1.1.21` instead of `v1.1.21`, so the computed version became `go/starter/template/v1.1.22`.

Why it was latent: release `v` tags used to be annotated, and `git describe --tags` prefers annotated tags over lightweight ones on the same commit — so the `v` tag always won. The most recent `v` tag happens to be lightweight, which exposed the gap.

## Fix

```diff
- LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.1.0")
+ LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || echo "v1.1.0")
```

`--match` restricts the lookup to semver release tags, so `go/*` (and any non-semver) tags are never picked — regardless of annotated vs lightweight. Verified against current master: `git describe ... --match 'v[0-9]*.[0-9]*.[0-9]*'` returns `v1.1.21`.

## State

The failed run died at step 2 (before any commit/tag/push), so master is clean — nothing for the attempted version was created. Re-running the release after this merges will compute the version correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
