### PR TITLE
ci: use client-id instead of deprecated app-id for app token

### DIFF
--- a/.github/workflows/generate-clients.yaml
+++ b/.github/workflows/generate-clients.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: provider-sdk

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -139,7 +139,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: provider-sdk
@@ -350,7 +350,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: provider-sdk

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,7 +140,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.CI_APP_ID }}
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: provider-sdk


### PR DESCRIPTION
## Summary
Switch GitHub App auth in `publish.yaml` (×2), `generate-clients.yaml`, and `release.yaml` from the legacy `app-id: ${{ vars.CI_APP_ID }}` to `client-id: ${{ vars.CI_APP_CLIENT_ID }}` for `actions/create-github-app-token` (already on `@v3`).

`client-id` is GitHub's recommended identifier; `app-id` is now legacy. `CI_APP_CLIENT_ID` is an org-level Actions variable (visibility `all`), already available here — no repo-level setup needed. Same GitHub App, same private key (`CI_APP_PRIVATE_KEY`); only the identifier form changes.

Part of an org-wide consolidation onto `client-id` (context: t-0-network/backend#351) so the legacy `CI_APP_ID` variable can be retired afterwards (t-0-network/backend#1128).

## Test plan
- Touches `publish` / `generate-clients` / `release` auth. Confirm `create-github-app-token` still mints a token and the publish/clients steps authenticate (test run or post-merge check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
