### PR TITLE
feat: add CompleteManualAmlCheck example to all starters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,13 @@ jobs:
         working-directory: go
         run: go test -v ./...
 
+      # The starter template is a nested Go module, so `go test ./...` above
+      # never compiles it. It pins the published SDK (no replace directive),
+      # so this validates the template against the released SDK.
+      - name: Build starter template
+        working-directory: go/starter/template
+        run: go build ./...
+
   node:
     name: Node
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -197,3 +204,27 @@ jobs:
       - name: Test
         working-directory: csharp
         run: dotnet test --no-build
+
+      # The C# starter template lives as string constants in TemplateFiles.cs
+      # and is otherwise never compiled — without this guard, template code
+      # that doesn't build is only caught when a provider scaffolds a project.
+      # Generate a project and build it against the locally packed SDK so
+      # unreleased SDK changes are covered too.
+      - name: Pack SDK
+        working-directory: csharp/sdk/T0.ProviderSdk
+        run: dotnet pack -c Release -p:Version=0.0.0-ci -o ${{ runner.temp }}/nupkg
+
+      - name: Generate starter project
+        working-directory: ${{ runner.temp }}
+        run: dotnet run --project $GITHUB_WORKSPACE/csharp/starter/T0.ProviderStarter -- template-check --no-color
+
+      - name: Point generated project at local SDK
+        working-directory: ${{ runner.temp }}/template-check
+        run: |
+          dotnet new nugetconfig
+          dotnet nuget add source ${{ runner.temp }}/nupkg --name local-sdk --configfile nuget.config
+          dotnet add package T0.ProviderSdk --version 0.0.0-ci
+
+      - name: Build generated project
+        working-directory: ${{ runner.temp }}/template-check
+        run: dotnet build

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -31,7 +31,8 @@ your-project/
 │   ├── PaymentHandler.cs        # ProviderService implementation (modify this)
 │   ├── QuotePublisher.cs        # Quote publishing logic (modify this)
 │   ├── GetQuote.cs              # Quote fetching utility
-│   └── SubmitPayment.cs         # Payment submission utility
+│   ├── SubmitPayment.cs         # Payment submission utility
+│   └── CompleteManualAmlCheck.cs # Manual AML check completion utility
 ├── Program.cs                   # Entry point
 ├── your-project.csproj          # Build configuration
 ├── appsettings.json             # ASP.NET Core configuration
@@ -73,6 +74,7 @@ your-project/
 3. Implement `PayOut` handler in `Services/PaymentHandler.cs`.
 4. Test payment submission using the included `SubmitPayment` utility.
 5. Coordinate with the T-0 team to test end-to-end payment flows.
+6. Optional: if your `PayOut` handler responds with a manual AML check, report the outcome using the included `CompleteManualAmlCheck` utility.
 
 ## Installation
 

--- a/csharp/starter/T0.ProviderStarter/TemplateFiles.cs
+++ b/csharp/starter/T0.ProviderStarter/TemplateFiles.cs
@@ -164,6 +164,12 @@ public static class TemplateFiles
                 logger.LogInformation("PayOut: payment_id={PaymentId}, currency={Currency}",
                     request.PaymentId, request.Currency);
 
+                // optional: if this payment needs a manual AML check on your side, respond with
+                // ManualAmlCheck here, before making the payout, and report the outcome later via
+                // CompleteManualAmlCheck (see Services/CompleteManualAmlCheck.cs). Do not finalize on
+                // this path — the payout only proceeds once the check is approved.
+                // return new PayoutResponse { ManualAmlCheck = new PayoutResponse.Types.ManualAmlCheck() };
+
                 // TODO: FinalizePayout should be called when your system completes the payout
                 await networkClient.FinalizePayoutAsync(new FinalizePayoutRequest
                 {
@@ -179,11 +185,6 @@ public static class TemplateFiles
                         }
                     }
                 });
-
-                // Alternatively, if this payment requires a manual AML check, respond with
-                // ManualAmlCheck instead of Accepted, then report the outcome later via
-                // CompleteManualAmlCheck (see Services/CompleteManualAmlCheck.cs):
-                // return new PayoutResponse { ManualAmlCheck = new PayoutResponse.Types.ManualAmlCheck() };
 
                 // optional: if your provider has multiple legal entities, set BeneficiaryProviderLegalEntityId
                 return new PayoutResponse { Accepted = new PayoutResponse.Types.Accepted() };

--- a/csharp/starter/T0.ProviderStarter/TemplateFiles.cs
+++ b/csharp/starter/T0.ProviderStarter/TemplateFiles.cs
@@ -19,6 +19,7 @@ public static class TemplateFiles
         ["Services/QuotePublisher.cs"] = QuotePublisher,
         ["Services/GetQuote.cs"] = GetQuote,
         ["Services/SubmitPayment.cs"] = SubmitPayment,
+        ["Services/CompleteManualAmlCheck.cs"] = CompleteManualAmlCheck,
     };
 
     public static IReadOnlyDictionary<string, string> All => AllFiles;
@@ -179,6 +180,11 @@ public static class TemplateFiles
                     }
                 });
 
+                // Alternatively, if this payment requires a manual AML check, respond with
+                // ManualAmlCheck instead of Accepted, then report the outcome later via
+                // CompleteManualAmlCheck (see Services/CompleteManualAmlCheck.cs):
+                // return new PayoutResponse { ManualAmlCheck = new PayoutResponse.Types.ManualAmlCheck() };
+
                 // optional: if your provider has multiple legal entities, set BeneficiaryProviderLegalEntityId
                 return new PayoutResponse { Accepted = new PayoutResponse.Types.Accepted() };
             }
@@ -217,6 +223,7 @@ public static class TemplateFiles
         using T0.ProviderSdk.Api.Tzero.V1.Common;
         using T0.ProviderSdk.Api.Tzero.V1.Payment;
         using T0.ProviderSdk.Hosting;
+        using Decimal = T0.ProviderSdk.Api.Tzero.V1.Common.Decimal;
 
         namespace {{PROJECT_NAME_PASCAL}}.Services;
 
@@ -270,6 +277,7 @@ public static class TemplateFiles
         """
         using T0.ProviderSdk.Api.Tzero.V1.Common;
         using T0.ProviderSdk.Api.Tzero.V1.Payment;
+        using Decimal = T0.ProviderSdk.Api.Tzero.V1.Common.Decimal;
 
         namespace {{PROJECT_NAME_PASCAL}}.Services;
 
@@ -293,7 +301,7 @@ public static class TemplateFiles
                     switch (response.ResultCase)
                     {
                         case GetQuoteResponse.ResultOneofCase.Success:
-                            Console.WriteLine($"Step 1.4: Got quote id={response.Success.QuoteId.QuoteId}");
+                            Console.WriteLine($"Step 1.4: Got quote id={response.Success.QuoteId.QuoteId_}");
                             break;
                         case GetQuoteResponse.ResultOneofCase.Failure:
                             Console.WriteLine($"Quote failed: {response.Failure.Reason}");
@@ -312,6 +320,7 @@ public static class TemplateFiles
         """
         using T0.ProviderSdk.Api.Tzero.V1.Common;
         using T0.ProviderSdk.Api.Tzero.V1.Payment;
+        using Decimal = T0.ProviderSdk.Api.Tzero.V1.Common.Decimal;
 
         namespace {{PROJECT_NAME_PASCAL}}.Services;
 
@@ -354,6 +363,51 @@ public static class TemplateFiles
                 catch (Grpc.Core.RpcException ex)
                 {
                     Console.WriteLine($"Error submitting payment: {ex.Status.StatusCode} - {ex.Message}");
+                }
+            }
+        }
+        """;
+
+    private const string CompleteManualAmlCheck =
+        """
+        using T0.ProviderSdk.Api.Tzero.V1.Payment;
+
+        namespace {{PROJECT_NAME_PASCAL}}.Services;
+
+        // TODO: Step 2.6 (optional) Complete manual AML checks.
+        // Pay-Out Provider role: if your PayOut handler returned ManualAmlCheck instead of
+        // Accepted (see Services/PaymentHandler.cs), run your AML check out-of-band and
+        // report the outcome with this call.
+        public static class CompleteManualAmlCheck
+        {
+            public static async Task CompleteAsync(NetworkService.NetworkServiceClient client, ulong paymentId)
+            {
+                try
+                {
+                    var response = await client.CompleteManualAmlCheckAsync(new CompleteManualAmlCheckRequest
+                    {
+                        PaymentId = paymentId,
+                        Approved = new CompleteManualAmlCheckRequest.Types.Approved()
+                        // If your check failed, report a rejection instead:
+                        // Rejected = new CompleteManualAmlCheckRequest.Types.Rejected { Reason = "AML check failed" }
+                    });
+
+                    switch (response.ResultCase)
+                    {
+                        case CompleteManualAmlCheckResponse.ResultOneofCase.Approved:
+                            // Pay-in provider approved the updated quotes — proceed with the payout using
+                            // the updated amounts, then report the outcome via FinalizePayout.
+                            Console.WriteLine($"Manual AML check approved for payment {paymentId}: payOutAmount={response.Approved.PayOutAmount}, settlementAmount={response.Approved.SettlementAmount}, quoteId={response.Approved.PayOutQuoteId}, clientQuoteId={response.Approved.PayOutClientQuoteId}");
+                            break;
+                        case CompleteManualAmlCheckResponse.ResultOneofCase.Rejected:
+                            // Pay-in provider rejected the updated quotes — do NOT proceed with the payout.
+                            Console.WriteLine($"Updated quotes rejected for payment {paymentId}, do not proceed with the payout");
+                            break;
+                    }
+                }
+                catch (Grpc.Core.RpcException ex)
+                {
+                    Console.WriteLine($"Error completing manual AML check: {ex.Status.StatusCode} - {ex.Message}");
                 }
             }
         }

--- a/docs/csharp/QUICKSTART.md
+++ b/docs/csharp/QUICKSTART.md
@@ -53,6 +53,7 @@ await server.RunAsync();
 7. **Step 2.3** — Test payment submission via `SubmitPayment`
 8. **Step 2.4** — Implement `PayOut` handler
 9. **Step 2.5** — Ask T-0 team to test payout to your provider
+10. **Step 2.6 (optional)** — Complete manual AML checks via `CompleteManualAmlCheck` if your `PayOut` handler returns `ManualAmlCheck`
 
 ## PaymentIntent Support
 

--- a/docs/python/ARCHITECTURE.md
+++ b/docs/python/ARCHITECTURE.md
@@ -265,6 +265,7 @@ The provider calls these RPCs on the T-0 Network.
 | `UpdateQuote` | Publish pay-out and pay-in quotes with rate bands |
 | `GetQuote` | Request a quote for a specific currency and payment method |
 | `FinalizePayout` | Report the outcome of a payout (success with receipt or failure) |
+| `CompleteManualAmlCheck` | Report the outcome of a manual AML check for a payout (approved or rejected) |
 
 ### 2.4 Transport Protocol
 

--- a/go/starter/README.md
+++ b/go/starter/README.md
@@ -26,7 +26,8 @@ my-provider/
 │   ├── publish_payment_intent_quotes.go       # Phase 3A: pay-in quote publishing
 │   ├── get_payment_intent_quote.go            # Phase 3B: indicative quote retrieval
 │   ├── create_payment_intent.go               # Phase 3B: create a payment intent
-│   └── confirm_funds_received.go              # Phase 3A: confirm funds received
+│   ├── confirm_funds_received.go              # Phase 3A: confirm funds received
+│   └── complete_manual_aml_check.go           # Phase 2: report a manual AML check outcome
 ├── .env                                       # Environment variables (with generated keys)
 ├── .env.example                               # Example environment file
 ├── .gitignore                                 # Git ignore rules
@@ -67,6 +68,7 @@ my-provider/
 2. Deploy your service and share the base URL with the T-0 team.
 3. Implement `PayOut` handler in `internal/handler/payment.go`.
 4. Coordinate with the T-0 team to test end-to-end payment flows.
+5. *(Optional)* If your `PayOut` handler responds with `manual_aml_check`, report the outcome of your AML check via `CompleteManualAmlCheck` (see `internal/complete_manual_aml_check.go`).
 
 ### Phase 3: Payment Intent Flow
 

--- a/go/starter/template/cmd/main.go
+++ b/go/starter/template/cmd/main.go
@@ -67,6 +67,9 @@ func main() {
 	// TODO: Step 2.2 Deploy your integration and provide t-0 team with the base URL
 	// TODO: Step 2.3 Test payment submission
 	// TODO: Step 2.5 Ask t-0 team to submit a payment to test your payOut endpoint
+	// TODO: Step 2.6 (optional) If your PayOut handler returns manual_aml_check, report the
+	// outcome of your AML check (see internal/complete_manual_aml_check.go)
+	// internal.CompleteManualAmlCheck(ctx, networkClient, paymentId)
 }
 
 func loadConfig() Config {

--- a/go/starter/template/go.sum
+++ b/go/starter/template/go.sum
@@ -36,6 +36,8 @@ github.com/rodaine/protogofakeit v0.1.1 h1:ZKouljuRM3A+TArppfBqnH8tGZHOwM/pjvtXe
 github.com/rodaine/protogofakeit v0.1.1/go.mod h1:pXn/AstBYMaSfc1/RqH3N82pBuxtWgejz1AlYpY1mI0=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/t-0-network/provider-sdk/go v1.1.24 h1:TfECrAQifepgq+4Fuv5ZRtPg7uZZl0j2KdOQO0WaCn8=
+github.com/t-0-network/provider-sdk/go v1.1.24/go.mod h1:7CMyIzIjpOgrj8qhV7eUqtmP1zcl3uVDlxsn0Hxt194=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=

--- a/go/starter/template/internal/complete_manual_aml_check.go
+++ b/go/starter/template/internal/complete_manual_aml_check.go
@@ -1,0 +1,52 @@
+package internal
+
+import (
+	"context"
+	"log"
+
+	"connectrpc.com/connect"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment"
+	"github.com/t-0-network/provider-sdk/go/api/tzero/v1/payment/paymentconnect"
+)
+
+// CompleteManualAmlCheck reports the outcome of a manual AML check to the t-0 Network.
+//
+// Pay-Out Provider role — Step 2.6 (optional).
+// Call this if your PayOut handler returned manual_aml_check instead of accepted
+// (see internal/handler/payment.go) and you have finished the AML check out-of-band.
+// On approval the response carries the updated pay-out amounts and quote ids —
+// proceed with the payout using those. On rejection do not proceed with the payout.
+func CompleteManualAmlCheck(
+	ctx context.Context,
+	networkClient paymentconnect.NetworkServiceClient,
+	paymentId uint64,
+) {
+	response, err := networkClient.CompleteManualAmlCheck(ctx, connect.NewRequest(&payment.CompleteManualAmlCheckRequest{
+		PaymentId: paymentId,
+		Result: &payment.CompleteManualAmlCheckRequest_Approved_{
+			Approved: &payment.CompleteManualAmlCheckRequest_Approved{},
+		},
+		// If your check failed, report a rejection instead:
+		// Result: &payment.CompleteManualAmlCheckRequest_Rejected_{
+		// 	Rejected: &payment.CompleteManualAmlCheckRequest_Rejected{Reason: "AML check failed"},
+		// },
+	}))
+	if err != nil {
+		log.Printf("Error completing manual AML check: %s\n", err.Error())
+		return
+	}
+
+	switch r := response.Msg.Result.(type) {
+	case *payment.CompleteManualAmlCheckResponse_Approved_:
+		// Pay-in provider approved the updated quotes — proceed with the payout using
+		// the updated amounts, then report the outcome via FinalizePayout.
+		log.Printf("Manual AML check approved for payment %d: pay-out amount %v, settlement amount %v, quote id %d, client quote id %s\n",
+			paymentId, r.Approved.GetPayOutAmount(), r.Approved.GetSettlementAmount(),
+			r.Approved.GetPayOutQuoteId(), r.Approved.GetPayOutClientQuoteId())
+	case *payment.CompleteManualAmlCheckResponse_Rejected_:
+		// Pay-in provider rejected the updated quotes — do NOT proceed with the payout.
+		log.Printf("Updated quotes rejected for payment %d, do not proceed with the payout\n", paymentId)
+	default:
+		log.Println("Unknown response type")
+	}
+}

--- a/go/starter/template/internal/handler/payment.go
+++ b/go/starter/template/internal/handler/payment.go
@@ -36,6 +36,16 @@ func (s *ProviderServiceImplementation) UpdatePayment(
 func (s *ProviderServiceImplementation) PayOut(ctx context.Context, req *connect.Request[payment.PayoutRequest],
 ) (*connect.Response[payment.PayoutResponse], error) {
 
+	// optional: if this payout requires a manual AML check on your side, return ManualAmlCheck here,
+	// before making the payout, and report the check outcome later via CompleteManualAmlCheck
+	// (see internal/complete_manual_aml_check.go). Do not finalize on this path — the payout only
+	// proceeds once the check is approved.
+	// return connect.NewResponse(&payment.PayoutResponse{
+	// 	Result: &payment.PayoutResponse_ManualAmlCheck_{
+	// 		ManualAmlCheck: &payment.PayoutResponse_ManualAmlCheck{},
+	// 	},
+	// }), nil
+
 	//TODO: FinalizePayout should be called when your system notifies that payout has been made successfully
 	_, err := s.networkClient.FinalizePayout(ctx, connect.NewRequest(&payment.FinalizePayoutRequest{
 		PaymentId: req.Msg.PaymentId,
@@ -54,15 +64,9 @@ func (s *ProviderServiceImplementation) PayOut(ctx context.Context, req *connect
 		return nil, err
 	}
 	// optional: if your provider has multiple legal entities, set BeneficiaryProviderLegalEntityId
-	// optional: if the payout requires a manual AML check, respond with ManualAmlCheck instead of
-	// the default (accepted) response, run the check out-of-band, then report the outcome via
-	// CompleteManualAmlCheck (see internal/complete_manual_aml_check.go):
-	// return connect.NewResponse(&payment.PayoutResponse{
-	// 	Result: &payment.PayoutResponse_ManualAmlCheck_{
-	// 		ManualAmlCheck: &payment.PayoutResponse_ManualAmlCheck{},
-	// 	},
-	// }), nil
-	return connect.NewResponse(&payment.PayoutResponse{}), nil
+	return connect.NewResponse(&payment.PayoutResponse{
+		Result: &payment.PayoutResponse_Accepted_{Accepted: &payment.PayoutResponse_Accepted{}},
+	}), nil
 }
 
 func (s *ProviderServiceImplementation) UpdateLimit(

--- a/go/starter/template/internal/handler/payment.go
+++ b/go/starter/template/internal/handler/payment.go
@@ -54,6 +54,14 @@ func (s *ProviderServiceImplementation) PayOut(ctx context.Context, req *connect
 		return nil, err
 	}
 	// optional: if your provider has multiple legal entities, set BeneficiaryProviderLegalEntityId
+	// optional: if the payout requires a manual AML check, respond with ManualAmlCheck instead of
+	// the default (accepted) response, run the check out-of-band, then report the outcome via
+	// CompleteManualAmlCheck (see internal/complete_manual_aml_check.go):
+	// return connect.NewResponse(&payment.PayoutResponse{
+	// 	Result: &payment.PayoutResponse_ManualAmlCheck_{
+	// 		ManualAmlCheck: &payment.PayoutResponse_ManualAmlCheck{},
+	// 	},
+	// }), nil
 	return connect.NewResponse(&payment.PayoutResponse{}), nil
 }
 

--- a/java/starter/template/README.md
+++ b/java/starter/template/README.md
@@ -42,6 +42,7 @@ Follow these steps in order to complete your integration:
 3. **Step 2.3** Test payment submission (uncomment in `Main.java`)
 4. **Step 2.4** Implement `payOut` in `PaymentHandler.java`
 5. **Step 2.5** Ask T-0 team to submit a test payment
+6. **Step 2.6** *(optional)* If your `payOut` responds with `manual_aml_check`, report the outcome via `internal/CompleteManualAmlCheck.java`
 
 ### Step 3: Payment Intent Flow
 
@@ -77,6 +78,7 @@ src/main/java/network/t0/provider/
     ├── PublishQuotes.java                   # Phase 1: payout quote publishing
     ├── GetQuote.java                        # Phase 1: quote retrieval
     ├── SubmitPayment.java                   # Phase 2: payment submission
+    ├── CompleteManualAmlCheck.java          # Phase 2: manual AML check completion (optional)
     ├── PublishPaymentIntentQuotes.java      # Phase 3A: pay-in quote publishing
     ├── GetPaymentIntentQuote.java           # Phase 3B: indicative quote retrieval
     ├── CreatePaymentIntent.java             # Phase 3B: create a payment intent

--- a/java/starter/template/src/main/java/network/t0/provider/Main.java
+++ b/java/starter/template/src/main/java/network/t0/provider/Main.java
@@ -96,6 +96,7 @@ public class Main {
         // TODO: Step 2.2 Deploy your integration and provide t-0 team with the base URL
         // TODO: Step 2.3 Test payment submission (see SubmitPayment.java)
         // TODO: Step 2.5 Ask t-0 team to submit a payment to test your payOut endpoint
+        // TODO: Step 2.6 (optional) Complete manual AML checks if your payOut returns manual_aml_check (see CompleteManualAmlCheck.java)
     }
 
     private static Config loadConfig() {

--- a/java/starter/template/src/main/java/network/t0/provider/handler/PaymentHandler.java
+++ b/java/starter/template/src/main/java/network/t0/provider/handler/PaymentHandler.java
@@ -64,6 +64,12 @@ public class PaymentHandler extends ProviderServiceGrpc.ProviderServiceImplBase 
                 request.getCurrency(),
                 request.getAmount());
 
+        // optional: if this payout needs a manual AML check on your side, respond with
+        // setManualAmlCheck(PayoutResponse.ManualAmlCheck.newBuilder().build()) here, before making
+        // the payout, and report the outcome later via CompleteManualAmlCheck.complete(...)
+        // (see internal/CompleteManualAmlCheck.java). Do not finalize on this path — the payout
+        // only proceeds once the check is approved.
+
         // TODO: Implement your payout logic here
         // 1. Validate the payout request
         // 2. Initiate the payout in your system
@@ -71,9 +77,6 @@ public class PaymentHandler extends ProviderServiceGrpc.ProviderServiceImplBase 
 
         // Example: Accept the payout
         // optional: if your provider has multiple legal entities, set setBeneficiaryProviderLegalEntityId()
-        // Alternatively, if this payout needs a manual AML check first, respond with
-        // setManualAmlCheck(PayoutResponse.ManualAmlCheck.newBuilder().build()) instead of
-        // setAccepted(...), then report the outcome later (see internal/CompleteManualAmlCheck.java).
         responseObserver.onNext(PayoutResponse.newBuilder()
                 .setAccepted(PayoutResponse.Accepted.newBuilder().build())
                 .build());

--- a/java/starter/template/src/main/java/network/t0/provider/handler/PaymentHandler.java
+++ b/java/starter/template/src/main/java/network/t0/provider/handler/PaymentHandler.java
@@ -45,6 +45,9 @@ public class PaymentHandler extends ProviderServiceGrpc.ProviderServiceImplBase 
             case MANUAL_AML_CHECK -> {
                 log.info("Payment {} requires manual AML check", request.getPaymentId());
                 // TODO: Handle manual AML check requirement
+                // This is the pay-in side notification: the pay-out provider is running a manual
+                // AML check. Once it approves, expect an approvePaymentQuotes "last look" call.
+                // The pay-out side of this flow is shown in internal/CompleteManualAmlCheck.java.
             }
             default -> log.warn("Unknown result type for payment {}", request.getPaymentId());
         }
@@ -68,6 +71,9 @@ public class PaymentHandler extends ProviderServiceGrpc.ProviderServiceImplBase 
 
         // Example: Accept the payout
         // optional: if your provider has multiple legal entities, set setBeneficiaryProviderLegalEntityId()
+        // Alternatively, if this payout needs a manual AML check first, respond with
+        // setManualAmlCheck(PayoutResponse.ManualAmlCheck.newBuilder().build()) instead of
+        // setAccepted(...), then report the outcome later (see internal/CompleteManualAmlCheck.java).
         responseObserver.onNext(PayoutResponse.newBuilder()
                 .setAccepted(PayoutResponse.Accepted.newBuilder().build())
                 .build());

--- a/java/starter/template/src/main/java/network/t0/provider/internal/CompleteManualAmlCheck.java
+++ b/java/starter/template/src/main/java/network/t0/provider/internal/CompleteManualAmlCheck.java
@@ -1,0 +1,53 @@
+package network.t0.provider.internal;
+
+import network.t0.sdk.proto.tzero.v1.payment.CompleteManualAmlCheckRequest;
+import network.t0.sdk.proto.tzero.v1.payment.CompleteManualAmlCheckResponse;
+import network.t0.sdk.proto.tzero.v1.payment.NetworkServiceGrpc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Pay-Out Provider role — Step 2.6 (optional).
+ *
+ * <p>If your payOut handler returned manual_aml_check instead of accepted (see
+ * handler/PaymentHandler.java), run your AML check out-of-band and report the
+ * outcome with this call. On approval the response carries the updated amounts
+ * and quote ids (re-approved by the pay-in provider via the "last look"); on
+ * rejection the payout must not proceed.
+ */
+public class CompleteManualAmlCheck {
+
+    private static final Logger log = LoggerFactory.getLogger(CompleteManualAmlCheck.class);
+
+    public static void complete(
+            NetworkServiceGrpc.NetworkServiceBlockingStub networkClient,
+            long paymentId) {
+        try {
+            CompleteManualAmlCheckResponse response = networkClient.completeManualAmlCheck(
+                    CompleteManualAmlCheckRequest.newBuilder()
+                            .setPaymentId(paymentId)
+                            .setApproved(CompleteManualAmlCheckRequest.Approved.newBuilder().build())
+                            // If your check failed, report a rejection instead:
+                            // .setRejected(CompleteManualAmlCheckRequest.Rejected.newBuilder()
+                            //         .setReason("AML check failed").build())
+                            .build());
+
+            switch (response.getResultCase()) {
+                case APPROVED -> {
+                    // Pay-in provider approved the updated quotes — proceed with the payout using
+                    // the updated amounts, then report the outcome via finalizePayout.
+                    CompleteManualAmlCheckResponse.Approved approved = response.getApproved();
+                    log.info("Manual AML check approved for payment {}: payOutAmount={}, settlementAmount={}, quoteId={}, clientQuoteId={}",
+                            paymentId, approved.getPayOutAmount(), approved.getSettlementAmount(),
+                            approved.getPayOutQuoteId(), approved.getPayOutClientQuoteId());
+                }
+                case REJECTED ->
+                        // Pay-in provider rejected the updated quotes — do NOT proceed with the payout.
+                        log.warn("Updated quotes rejected for payment {}, do not proceed with the payout", paymentId);
+                default -> log.warn("Unknown result type for payment {}", paymentId);
+            }
+        } catch (io.grpc.StatusRuntimeException e) {
+            log.error("Error completing manual AML check: {} - {}", e.getStatus().getCode(), e.getMessage());
+        }
+    }
+}

--- a/node/starter/README.md
+++ b/node/starter/README.md
@@ -26,6 +26,7 @@ your-project-name/
 │   ├── create_payment_intent.ts                  # Phase 3B: create a payment intent
 │   ├── confirm_funds_received.ts                 # Phase 3A: confirm funds received
 │   ├── submit_payment.ts                         # Phase 2: payment submission
+│   ├── complete_manual_aml_check.ts              # Phase 2: manual AML check completion
 │   └── lib.ts                                    # Utility functions
 ├── Dockerfile                                    # Docker configuration
 ├── .env                                          # Environment variables (with generated keys)
@@ -69,6 +70,7 @@ your-project-name/
 3. Implement `payOut` handler in `src/service.ts`.
 4. Test payment submission by uncommenting the `submitPayment` call in `src/index.ts`.
 5. Coordinate with the T-0 team to test end-to-end payment flows.
+6. (Optional) If your `payOut` handler responds with `manualAmlCheck`, report the check outcome via `src/complete_manual_aml_check.ts`.
 
 ### Phase 3: Payment Intent Flow
 

--- a/node/starter/template/src/complete_manual_aml_check.ts
+++ b/node/starter/template/src/complete_manual_aml_check.ts
@@ -1,0 +1,32 @@
+import {type Client, NetworkService} from "@t-0/provider-sdk";
+
+export default async function completeManualAmlCheck(
+    networkClient: Client<typeof NetworkService>,
+    paymentId: bigint,
+): Promise<void> {
+  // Pay-Out Provider role — Step 2.6 (optional). If your payOut handler returned
+  // manualAmlCheck instead of accepted (see ./service.ts), run your AML check
+  // out-of-band and report the outcome with this call.
+  const response = await networkClient.completeManualAmlCheck({
+    paymentId,
+    result: {case: 'approved', value: {}},
+    // If your check failed, report a rejection instead:
+    // result: {case: 'rejected', value: {reason: 'AML check failed'}},
+  })
+
+  switch (response.result.case) {
+    case 'approved': {
+      const approved = response.result.value;
+      // Pay-in provider approved the updated quotes — proceed with the payout using
+      // the updated amounts, then report the outcome via finalizePayout.
+      console.log(`Manual AML check approved for payment ${paymentId}: quoteId=${approved.payOutQuoteId}, clientQuoteId=${approved.payOutClientQuoteId}`, 'payOutAmount=', approved.payOutAmount, 'settlementAmount=', approved.settlementAmount)
+      break;
+    }
+    case 'rejected':
+      // Pay-in provider rejected the updated quotes — do NOT proceed with the payout.
+      console.log(`Updated quotes rejected for payment ${paymentId}, do not proceed with the payout`)
+      break;
+    default:
+      console.error("unexpected result type")
+  }
+}

--- a/node/starter/template/src/index.ts
+++ b/node/starter/template/src/index.ts
@@ -17,6 +17,8 @@ import CreateProviderService from "./service";
 import getQuote from "./get_quote";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import submitPayment from "./submit_payment";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import completeManualAmlCheck from "./complete_manual_aml_check";
 import CreatePayInProviderService from "./payment_intent_pay_in_service";
 import CreateBeneficiaryService from "./payment_intent_beneficiary_service";
 import publishPaymentIntentQuotes from "./publish_payment_intent_quotes";
@@ -76,6 +78,9 @@ async function main() {
   // await submitPayment(networkClient)
 
   // TODO: Step 2.5 ask t-0 team to submit a payment which would trigger your payOut endpoint
+
+  // TODO: Step 2.6 (optional) if your payOut returns manualAmlCheck, report the check result by revisiting ./complete_manual_aml_check.ts uncommenting following line
+  // await completeManualAmlCheck(networkClient, paymentId)
 
   // ──────────────────────────────────────────────────────────────
   // Payment Intent Flow — Phase 3

--- a/node/starter/template/src/service.ts
+++ b/node/starter/template/src/service.ts
@@ -29,6 +29,12 @@ const CreateProviderService = (networkClient: Client<typeof NetworkService>) => 
             // TODO: Step 2.4 implement how you do payouts (payments initiated by your counterparts)
             console.log(`Received payout request ${req.paymentId}`)
 
+            // optional: if this payout needs a manual AML check on your side, return manualAmlCheck
+            // here, before making the payout, and report the result later via
+            // ./complete_manual_aml_check.ts. Do not finalize on this path — the payout only
+            // proceeds once the check is approved.
+            // return { result: { case: "manualAmlCheck", value: {} } } as PayoutResponse
+
             // TODO: finalizePayout should be called when your system completes (or fails) the payout
             setInterval(() => {
                 networkClient.finalizePayout({
@@ -48,10 +54,6 @@ const CreateProviderService = (networkClient: Client<typeof NetworkService>) => 
                     }
                 })
             }, 2000);
-            // optional: if the payout needs a manual AML check on your side, return manualAmlCheck
-            // instead of accepted, then report the result via ./complete_manual_aml_check.ts:
-            // return { result: { case: "manualAmlCheck", value: {} } } as PayoutResponse
-
             // optional: if your provider has multiple legal entities, set beneficiaryProviderLegalEntityId
             return {
                 result: {

--- a/node/starter/template/src/service.ts
+++ b/node/starter/template/src/service.ts
@@ -48,6 +48,10 @@ const CreateProviderService = (networkClient: Client<typeof NetworkService>) => 
                     }
                 })
             }, 2000);
+            // optional: if the payout needs a manual AML check on your side, return manualAmlCheck
+            // instead of accepted, then report the result via ./complete_manual_aml_check.ts:
+            // return { result: { case: "manualAmlCheck", value: {} } } as PayoutResponse
+
             // optional: if your provider has multiple legal entities, set beneficiaryProviderLegalEntityId
             return {
                 result: {

--- a/python/starter/src/t0_provider_starter/template/src/provider/complete_manual_aml_check.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/complete_manual_aml_check.py
@@ -1,0 +1,52 @@
+"""Complete a manual AML check for a payout.
+
+Go equivalent: internal/complete_manual_aml_check.go → CompleteManualAmlCheck()
+
+Pay-Out Provider role — Step 2.6 (optional). If your pay_out handler returned
+manual_aml_check instead of accepted (see handler/payment.py), run your AML
+check out-of-band and report the outcome with this call. On approval the
+response carries updated amounts and quote ids re-approved by the pay-in
+provider; on rejection the payout must not proceed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from t0_provider_sdk.api.tzero.v1.payment.network_connect import NetworkServiceClient
+from t0_provider_sdk.api.tzero.v1.payment.network_pb2 import CompleteManualAmlCheckRequest
+
+logger = logging.getLogger(__name__)
+
+
+async def complete_manual_aml_check(
+    network_client: NetworkServiceClient,
+    payment_id: int,
+) -> None:
+    try:
+        response = await network_client.complete_manual_aml_check(
+            CompleteManualAmlCheckRequest(
+                payment_id=payment_id,
+                approved=CompleteManualAmlCheckRequest.Approved(),
+                # If your check failed, report a rejection instead:
+                # rejected=CompleteManualAmlCheckRequest.Rejected(reason="AML check failed"),
+            ),
+        )
+
+        if response.HasField("approved"):
+            # Pay-in provider approved the updated quotes — proceed with the payout using
+            # the updated amounts, then report the outcome via finalize_payout.
+            logger.info(
+                "Manual AML check approved for payment %d: pay_out_amount=%s settlement_amount=%s "
+                "pay_out_quote_id=%d pay_out_client_quote_id=%s",
+                payment_id,
+                response.approved.pay_out_amount,
+                response.approved.settlement_amount,
+                response.approved.pay_out_quote_id,
+                response.approved.pay_out_client_quote_id,
+            )
+        elif response.HasField("rejected"):
+            # Pay-in provider rejected the updated quotes — do NOT proceed with the payout.
+            logger.info("Updated quotes rejected for payment %d, do not proceed with the payout", payment_id)
+    except Exception:
+        logger.exception("Error completing manual AML check")

--- a/python/starter/src/t0_provider_starter/template/src/provider/handler/payment.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/handler/payment.py
@@ -61,6 +61,10 @@ class ProviderServiceImplementation:
         )
 
         # optional: if your provider has multiple legal entities, set beneficiary_provider_legal_entity_id
+
+        # If this payout requires a manual AML check on your side, return
+        # PayoutResponse(manual_aml_check=PayoutResponse.ManualAmlCheck()) instead,
+        # then report the outcome later — see complete_manual_aml_check.py.
         return PayoutResponse()
 
     async def update_limit(self, request: UpdateLimitRequest, ctx: RequestContext) -> UpdateLimitResponse:

--- a/python/starter/src/t0_provider_starter/template/src/provider/handler/payment.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/handler/payment.py
@@ -45,6 +45,11 @@ class ProviderServiceImplementation:
 
     # TODO: Step 2.4 implement how you do payouts (payments initiated by your counterparts)
     async def pay_out(self, request: PayoutRequest, ctx: RequestContext) -> PayoutResponse:
+        # optional: if this payout requires a manual AML check on your side, return
+        # PayoutResponse(manual_aml_check=PayoutResponse.ManualAmlCheck()) here, before making the
+        # payout, and report the check outcome later via complete_manual_aml_check.py. Do not
+        # finalize on this path — the payout only proceeds once the check is approved.
+
         # TODO: FinalizePayout should be called when your system notifies
         # that payout has been made successfully
         await self._network_client.finalize_payout(
@@ -61,11 +66,7 @@ class ProviderServiceImplementation:
         )
 
         # optional: if your provider has multiple legal entities, set beneficiary_provider_legal_entity_id
-
-        # If this payout requires a manual AML check on your side, return
-        # PayoutResponse(manual_aml_check=PayoutResponse.ManualAmlCheck()) instead,
-        # then report the outcome later — see complete_manual_aml_check.py.
-        return PayoutResponse()
+        return PayoutResponse(accepted=PayoutResponse.Accepted())
 
     async def update_limit(self, request: UpdateLimitRequest, ctx: RequestContext) -> UpdateLimitResponse:
         # TODO: optionally implement handling of the notifications about

--- a/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_sync.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_sync.py
@@ -59,6 +59,10 @@ class ProviderServiceSyncImplementation:
         )
 
         # optional: if your provider has multiple legal entities, set beneficiary_provider_legal_entity_id
+
+        # If this payout requires a manual AML check on your side, return
+        # PayoutResponse(manual_aml_check=PayoutResponse.ManualAmlCheck()) instead,
+        # then report the outcome later — see complete_manual_aml_check.py.
         return PayoutResponse()
 
     def update_limit(self, request: UpdateLimitRequest, ctx: RequestContext) -> UpdateLimitResponse:

--- a/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_sync.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/handler/payment_sync.py
@@ -43,6 +43,11 @@ class ProviderServiceSyncImplementation:
 
     # TODO: Step 2.4 implement how you do payouts (payments initiated by your counterparts)
     def pay_out(self, request: PayoutRequest, ctx: RequestContext) -> PayoutResponse:
+        # optional: if this payout requires a manual AML check on your side, return
+        # PayoutResponse(manual_aml_check=PayoutResponse.ManualAmlCheck()) here, before making the
+        # payout, and report the check outcome later via complete_manual_aml_check.py. Do not
+        # finalize on this path — the payout only proceeds once the check is approved.
+
         # TODO: FinalizePayout should be called when your system notifies
         # that payout has been made successfully
         self._network_client.finalize_payout(
@@ -59,11 +64,7 @@ class ProviderServiceSyncImplementation:
         )
 
         # optional: if your provider has multiple legal entities, set beneficiary_provider_legal_entity_id
-
-        # If this payout requires a manual AML check on your side, return
-        # PayoutResponse(manual_aml_check=PayoutResponse.ManualAmlCheck()) instead,
-        # then report the outcome later — see complete_manual_aml_check.py.
-        return PayoutResponse()
+        return PayoutResponse(accepted=PayoutResponse.Accepted())
 
     def update_limit(self, request: UpdateLimitRequest, ctx: RequestContext) -> UpdateLimitResponse:
         # TODO: optionally implement handling of the notifications about

--- a/python/starter/src/t0_provider_starter/template/src/provider/main.py
+++ b/python/starter/src/t0_provider_starter/template/src/provider/main.py
@@ -48,6 +48,7 @@ from t0_provider_sdk.api.tzero.v1.payment_intent.pay_in_provider_connect import 
 from t0_provider_sdk.network.client import new_service_client
 from t0_provider_sdk.provider.handler import handler, new_asgi_app
 
+from provider.complete_manual_aml_check import complete_manual_aml_check  # noqa: F401
 from provider.config import Config, load_config
 from provider.create_payment_intent import create_payment_intent  # noqa: F401
 from provider.get_payment_intent_quote import get_payment_intent_quote
@@ -158,6 +159,8 @@ async def main() -> None:
     # TODO: Step 2.2 Deploy your integration and provide t-0 team with the base URL
     # TODO: Step 2.3 Test payment submission
     # TODO: Step 2.5 Ask t-0 team to submit a payment to test your payOut endpoint
+    # TODO: Step 2.6 (optional) Complete manual AML checks if your pay_out returns manual_aml_check
+    # await complete_manual_aml_check(network_client, payment_id)
 
     await server.serve()
 


### PR DESCRIPTION
## Summary

Reported by Andy: all starters were missing a `CompleteManualAmlCheck` example. Confirmed — the RPC exists in the proto ([`network.proto:67`](proto/tzero/v1/payment/network.proto)) and in every SDK's generated client, but no starter demonstrated it. Every neighbouring RPC in the flow has a per-language example; this one had none, so a pay-out provider implementing the manual-AML path got nothing from the scaffold.

Adds one reference example per starter, plus discovery hooks and docs. **It also fixes three pre-existing bugs that the new CI guards immediately caught — see below; the Go one is breaking scaffolding today.**

## The flow

A pay-out provider may answer `PayOut` with `PayoutResponse{manual_aml_check}` instead of `accepted`, run its AML check out-of-band, then call `CompleteManualAmlCheck` with `approved{}` or `rejected{reason}`. On approval the response carries updated amounts/quote ids (re-approved by the pay-in provider via the `ApprovePaymentQuotes` last look); on rejection the payout must not proceed.

## What's here

- **New example per starter** — `complete_manual_aml_check.{go,ts,py}`, `CompleteManualAmlCheck.{java,cs}` — each in its language's existing idiom: `approved` call live, `rejected{reason}` shown commented, both response branches handled.
- **Reference-only wiring**, matching the `SubmitPayment` / `create_payment_intent` precedent — the call needs a real payment id in manual-AML state, so it can't be auto-invoked.
- **Hooks** so the example is discoverable: each `PayOut` handler shows the `manual_aml_check` alternative; Java's existing `MANUAL_AML_CHECK` case cross-references the example; each entry point gets a `Step 2.6 (optional)` TODO.
- **Docs**: `go/starter/README.md`, `node/starter/README.md`, `java/starter/template/README.md`, `csharp/README.md`, `docs/csharp/QUICKSTART.md`, `docs/python/ARCHITECTURE.md`.

Shape follows d87d925 (one PR touching the same conceptual spot in all five starters).

## CI guards (new)

CI never compiled two of the five templates: the Go template is a nested module (`go test ./...` doesn't recurse into it) and the C# template lives as string constants in `TemplateFiles.cs`, so `dotnet build` only ever compiled the *starter tool*, never the *template*. Both now build in CI — Go via `go build ./...` in the template module, C# by generating a project and building it against the locally packed SDK (mirrors the Node job's overlay design, so unreleased SDK drift is covered too).

## Pre-existing bugs found and fixed

The guards paid for themselves immediately. All three verified against pristine `HEAD`, not inferred:

| Bug | Impact |
|---|---|
| `go/starter/template/go.sum` missing the SDK v1.1.24 hashes | **`go build` fails in default read-only mode — breaks Go scaffolding for customers today**, independently of the AML gap |
| C# template: 4× `CS0104` `Decimal` ambiguous (`ImplicitUsings` brings `System.Decimal` alongside `Common.Decimal`) | generated project won't build |
| C# template: `response.Success.QuoteId.QuoteId` → `QuoteId_` (protobuf appends `_` on name collision) | won't build; was *masked* by the `CS0104` errors until they were fixed |

The `QuoteId` line looks hand-ported from the Go example, where the same expression is valid — a fingerprint of a template that has never been compiled.

## Test plan

- [x] Go — `go build ./... && go vet ./... && gofmt -l .` in the template module, clean
- [x] Node — `tsc --noEmit -p tsconfig.typecheck.json` against the locally packed SDK, clean
- [x] Python — `ruff check .` + `ruff format --check .` clean; identifiers verified statically against the generated stubs (Python has no compile gate in CI, and the venv can't build here — `coincurve` won't compile)
- [x] Java — `./gradlew build -x distTar -x distZip` clean (`:starter:template` compiles against `:sdk`)
- [x] C# — `dotnet build` + 57 tests pass; **generated project builds with 0 errors**; C# CI guard simulated locally end-to-end (pack → generate → local nuget source → build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)