### PR TITLE
fix(node): repair starter template lockfile so scaffolded projects build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,11 +94,16 @@ jobs:
         run: npm pack
 
       - name: Install starter template dependencies
-        # `npm install` (not `npm ci`) because the template's package-lock.json
-        # is not strict-locked to the latest SDK — providers regenerate it on
-        # first install. We just need a working install for type checking.
+        # `npm ci`, not `npm install`: the template's package-lock.json ships
+        # to providers (create.ts copies the template wholesale) and the
+        # generated Dockerfile runs `npm ci`, which hard-fails if the lockfile
+        # and package.json disagree. Using `npm install` here would silently
+        # paper over that drift and leave every scaffolded project unable to
+        # `docker build`. Keep this as `npm ci` so CI fails the way a provider
+        # would. When release.yaml bumps the SDK pin in package.json, the
+        # lockfile must be regenerated alongside it.
         working-directory: node/starter/template
-        run: npm install --no-audit --no-fund
+        run: npm ci --no-audit --no-fund
 
       - name: Overlay local SDK build into template
         working-directory: node/starter/template

--- a/node/starter/template/package-lock.json
+++ b/node/starter/template/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@t-0/provider-sdk": "^1.0.64",
+        "@t-0/provider-sdk": "^1.1.24",
         "dotenv": "^16.3.1",
         "tiny-invariant": "^1.3.3"
       },
@@ -19,42 +19,86 @@
         "typescript": "^5.3.2"
       }
     },
+    "node_modules/@bufbuild/cel": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/@bufbuild/cel/-/cel-0.4.0.tgz",
+      "integrity": "sha512-CdW/JgiTJCYXqnwuaJRo7NcoYhR37AaF58MMiog0/t8nudn86ZyLXYaA1f2yGhm2U17h8pKGZNksTHVSTcpmAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/cel-spec": "0.4.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.6.2"
+      }
+    },
+    "node_modules/@bufbuild/cel-spec": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/@bufbuild/cel-spec/-/cel-spec-0.4.0.tgz",
+      "integrity": "sha512-dUS6f2fNt6KEumsYGE7YFxERZE5ZuyME1hQmGjtO8tkZhR6ow6/ne3v4Gik9cfdb9lSLK3AJ+vDxCdGWmDbWvA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.6.2"
+      }
+    },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.10.0.tgz",
-      "integrity": "sha512-fdRs9PSrBF7QUntpZpq6BTw58fhgGJojgg39m9oFOJGZT+nip9b0so5cYY1oWl5pvemDLr0cPPsH46vwThEbpQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmmirror.com/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
+    "node_modules/@bufbuild/protovalidate": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/@bufbuild/protovalidate/-/protovalidate-1.2.0.tgz",
+      "integrity": "sha512-tD08DwGrHIV88khLz1Kdz9DYUwEo1TsoepaIg7/B/zd//AymaTx67kvCS1jlkcG/+vgQaSOl6f0HCE3sL8vI7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/cel": "0.4.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.8.0"
+      }
+    },
     "node_modules/@connectrpc/connect": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.0.tgz",
-      "integrity": "sha512-xhiwnYlJNHzmFsRw+iSPIwXR/xweTvTw8x5HiwWp10sbVtd4OpOXbRgE7V58xs1EC17fzusF1f5uOAy24OkBuA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
     },
     "node_modules/@connectrpc/connect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.0.tgz",
-      "integrity": "sha512-6akCXZSX5uWHLR654ne9Tnq7AnPUkLS65NvgsI5885xBkcuVy2APBd8sA4sLqaplUt84cVEr6LhjEFNx6W1KtQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
+      "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.0"
+        "@connectrpc/connect": "2.1.2"
       }
     },
     "node_modules/@connectrpc/connect-web": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.0.tgz",
-      "integrity": "sha512-4IBFeMeXS1RVtmmFE/MwH+vWq/5vDRKys70va+DAaWDh83Rdy0iUQOJbITUDzvonlY5as3vwfs5yy9Yp2miHSw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/@connectrpc/connect-web/-/connect-web-2.1.2.tgz",
+      "integrity": "sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.0"
+        "@connectrpc/connect": "2.1.2"
+      }
+    },
+    "node_modules/@connectrpc/validate": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/@connectrpc/validate/-/validate-0.2.0.tgz",
+      "integrity": "sha512-u1hdyt1WaFkKpuT/3J2wYlCjYLkYHMZamoatgxTIsV5Q8H9fO2px3zecmb0Q47YDjkZqnX6z0PAEstK+dNYiEQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.9.0",
+        "@bufbuild/protovalidate": "^1.0.0",
+        "@connectrpc/connect": "^2.0.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -98,10 +142,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -110,26 +169,19 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@noble/secp256k1": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-2.3.0.tgz",
-      "integrity": "sha512-0TQed2gcBbIrh7Ccyw+y/uZQvbJwm7Ao4scBUxqpBCcsOlZG0O4KGfjtNAy/li4W8n1xt3dxrwJ0beZ2h2G6Kw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@t-0/provider-sdk": {
-      "version": "1.0.64",
-      "resolved": "https://registry.npmjs.org/@t-0/provider-sdk/-/provider-sdk-1.0.64.tgz",
-      "integrity": "sha512-Iivw2Pd1fG71a6N5CHPI/S2NSbMumiNTi2weFWbD4/FmmP+3JOjahfifRHAaMlyE61U2Go9K+glNHu43kVmzfw==",
+      "version": "1.1.24",
+      "resolved": "https://registry.npmmirror.com/@t-0/provider-sdk/-/provider-sdk-1.1.24.tgz",
+      "integrity": "sha512-/2I09Ov5jsCXUJedyHVnuWqWER0KiXkYxOubZbQ44MtWilzrZUDKYJiY8/Qft2nXrlgsaA4DNLw0HxIJcwijWA==",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.10.0",
-        "@connectrpc/connect": "^2.1.0",
-        "@connectrpc/connect-node": "^2.1.0",
-        "@connectrpc/connect-web": "^2.1.0",
-        "@noble/hashes": "^2.0.1",
-        "@noble/secp256k1": "^2.3.0"
+        "@bufbuild/protobuf": "^2.12.0",
+        "@bufbuild/protovalidate": "^1.2.0",
+        "@connectrpc/connect": "^2.1.1",
+        "@connectrpc/connect-node": "^2.1.1",
+        "@connectrpc/connect-web": "^2.1.1",
+        "@connectrpc/validate": "^0.2.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0"
       }
     },
     "node_modules/@tsconfig/node10": {


### PR DESCRIPTION
## Summary

**Every project scaffolded by the Node starter currently fails `docker build`.** Found while sweeping starter dependencies; unrelated to that sweep, so it's here on its own.

The template's `package-lock.json` pins `@t-0/provider-sdk@1.0.64` while `package.json` declares `^1.1.24`. `node/starter/src/create.ts:73` `copySync`s the template wholesale — lockfile included — into every scaffolded project, and the generated `Dockerfile:13` runs `npm ci`, which hard-errors when the two disagree:

```
npm error code EUSAGE
npm error Invalid: lock file's @t-0/provider-sdk@1.0.64 does not satisfy @t-0/provider-sdk@1.1.24
npm error Invalid: lock file's @bufbuild/protobuf@2.10.0 does not satisfy @bufbuild/protobuf@2.12.1
```

## Root cause

The drift [`CLAUDE.md`](CLAUDE.md) warns about: `release.yaml` bumps the SDK self-pin in the template's `package.json`, but nothing regenerates the adjacent lockfile. It has been drifting since ~1.0.64.

CI never caught it because the template job ran `npm install --no-save`, never `npm ci`. The step's own comment recorded the assumption that kept this invisible:

```yaml
# `npm install` (not `npm ci`) because the template's package-lock.json
# is not strict-locked to the latest SDK — providers regenerate it on
# first install. We just need a working install for type checking.
```

Providers do **not** regenerate it on first install — the Dockerfile runs `npm ci`, which by design never regenerates. The workaround papered over the bug it was working around.

## Fix

1. **Regenerate** `node/starter/template/package-lock.json` against the current `^1.1.24` pin.
2. **Switch the CI step to `npm ci`**, so the job now fails the same way a provider's `docker build` would, and replace the comment with one explaining why it must stay `npm ci`.

## Test plan

- [x] `npm ci` in `node/starter/template` — succeeds (was `EUSAGE`)
- [x] **Guard verified in both directions**, so it isn't decoration:
  - fails on master's drifted lockfile → `EUSAGE` (i.e. it would have caught this bug)
  - passes on the regenerated lockfile
- [x] Full CI-equivalent sequence passes clean: SDK build + pack → template `npm ci` → overlay local SDK → `tsc --noEmit`

## Follow-up worth considering (not in this PR)

This will silently return on the next release unless `release.yaml` regenerates the template lockfile when it bumps the SDK pin — the `npm ci` guard turns that from a silent break into a red build, but doesn't prevent it.

**The same root cause affects Python**: `python/uv.lock` records the editable self-versions as `1.1.20` while `pyproject.toml` says `1.1.24`, so any `uv` command in `python/` dirties the lock. Less severe (no `npm ci`-equivalent hard gate), but the same "release bumps the pin, nothing re-locks" pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)