### PR TITLE
fix: restore SDK go.sum entries in Go starter template

### DIFF
--- a/go/starter/template/go.sum
+++ b/go/starter/template/go.sum
@@ -36,6 +36,8 @@ github.com/rodaine/protogofakeit v0.1.1 h1:ZKouljuRM3A+TArppfBqnH8tGZHOwM/pjvtXe
 github.com/rodaine/protogofakeit v0.1.1/go.mod h1:pXn/AstBYMaSfc1/RqH3N82pBuxtWgejz1AlYpY1mI0=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/t-0-network/provider-sdk/go v1.1.25 h1:I8D3DQcj57Fs74edB+GpjWUNnU19pwSoiEap7EpmHE4=
+github.com/t-0-network/provider-sdk/go v1.1.25/go.mod h1:7CMyIzIjpOgrj8qhV7eUqtmP1zcl3uVDlxsn0Hxt194=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=


### PR DESCRIPTION
## Problem

Master CI is red since the merge of #178 — but the breakage predates it: the **Release 1.1.25** commit (8e6f690) left `go/starter/template` with go.mod pinning `provider-sdk/go v1.1.25` while deleting its go.sum entries, so the CI step "Build starter template" fails with `missing go.sum entry`. It went unnoticed because CI skips its jobs on release pushes (bot actor), and no CI-triggering push happened on master between Jul 16 and the #178 merge.

## Root cause

`release.yaml`'s template-bump step runs `go mod tidy` with a local `replace` for the SDK active. Go records **no go.sum checksums for locally-replaced modules**, so tidy removes the old version's entries and cannot add the new ones. A durable workflow fix is coming in a separate PR; this PR just unbreaks master.

## Fix

`go mod tidy` in `go/starter/template` now that v1.1.25 is published — restores exactly the two missing checksum lines. Verified locally: `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)