### PR TITLE
Cross vectors that cover the bodies and the failures

### DIFF
--- a/cross_test/README.md
+++ b/cross_test/README.md
@@ -11,8 +11,8 @@ a change here is a change every language has to agree with:
 | Python | `python/sdk/tests/crypto/test_cross_vectors.py` |
 | C# | `csharp/sdk/T0.ProviderSdk.Tests/Crypto/CrossTestVectors.cs` |
 
-Hex values carry no `0x` prefix. Signatures are 64 bytes, `r || s`, unless a case says
-otherwise; the recovery byte is appended by some SDKs and ignored by every verifier.
+Hex values carry no `0x` prefix. Signatures are 64 bytes (`r || s`) unless a case
+appends a recovery byte.
 
 ## The scheme
 
@@ -51,6 +51,7 @@ fixture.
 
 ## Adding a case
 
-Sign it with any one SDK and run the other four. A 65-byte signature has to carry the
-right recovery byte — Go, Java, Node and C# ignore it, but Python verifies by recovering
-the key from it, so a wrong `v` fails there and nowhere else.
+Sign it with any one SDK and run the other four. On the wire every SDK ignores `v`.
+Python's `verify_signature` helper — which the Python cross-vector test calls — does
+not, so fixture 65-byte signatures must carry the recovery byte that recovers the
+trusted key.

--- a/cross_test/README.md
+++ b/cross_test/README.md
@@ -1,0 +1,56 @@
+# Cross-language test vectors
+
+`test_vectors.json` is the shared fixture for the request signature. Every SDK reads it, so
+a change here is a change every language has to agree with:
+
+| SDK | Test |
+|---|---|
+| Go | `go/crypto/cross_test.go` |
+| Node | `node/sdk/test/crypto.test.ts` |
+| Java | `java/sdk/src/test/java/network/t0/sdk/crypto/CrossVectorTest.java` |
+| Python | `python/sdk/tests/crypto/test_cross_vectors.py` |
+| C# | `csharp/sdk/T0.ProviderSdk.Tests/Crypto/CrossTestVectors.cs` |
+
+Hex values carry no `0x` prefix. Signatures are 64 bytes, `r || s`, unless a case says
+otherwise; the recovery byte is appended by some SDKs and ignored by every verifier.
+
+## The scheme
+
+```
+digest    = keccak256(body || uint64le(timestamp_ms))
+signature = secp256k1 ECDSA over that 32-byte digest — RFC 6979 deterministic k
+            (HMAC-SHA256), low-S
+```
+
+Deterministic `k` is what lets a fixture name exact signature bytes: the same key and
+digest give the same `r` and `s` in every library, so a vector can be an equality
+assertion rather than a sign-then-verify round trip.
+
+## What is in the file
+
+| Key | Contents |
+|---|---|
+| `keys` | the key the signing cases use and the verification cases are checked against |
+| `impostor_keys` | a second key, for cases that must fail |
+| `keccak256` | text input → hash |
+| `request_signing` | one signing case with a text `body` |
+| `request_signing_cases` | signing cases with a `body_hex`, so a body can be binary, framed or empty |
+| `signature_verification` | a presented request → does it verify |
+
+`body_hex` is the exact preimage: whatever the transport put in the body, before the
+timestamp is appended and before anything decodes it. `grpc-framed-body` carries the gRPC
+frame (`0x00` + `uint32be(length)` + message) because that is what the network signs when
+it calls a provider over gRPC, while Connect callers sign the message alone — the Java
+provider verifies against both.
+
+`signature_verification` answers one question: does this signature verify against this
+public key for this body and timestamp. It stops there on purpose. Whether a request is
+*accepted* also depends on the timestamp window, which every provider measures against a
+clock only it can see, so that belongs in each SDK's own middleware tests, not in a shared
+fixture.
+
+## Adding a case
+
+Sign it with any one SDK and run the other four. A 65-byte signature has to carry the
+right recovery byte — Go, Java, Node and C# ignore it, but Python verifies by recovering
+the key from it, so a wrong `v` fails there and nowhere else.

--- a/cross_test/test_vectors.json
+++ b/cross_test/test_vectors.json
@@ -3,6 +3,10 @@
     "private_key": "6b30303de7b26bfb1222b317a52113357f8bb06de00160b4261a2fef9c8b9bd8",
     "public_key": "044fa1465c087aaf42e5ff707050b8f77d2ce92129c5f300686bdd3adfffe44567713bb7931632837c5268a832512e75599b6964f4484c9531c02e96d90384d9f0"
   },
+  "impostor_keys": {
+    "private_key": "2222222222222222222222222222222222222222222222222222222222222222",
+    "public_key": "04466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276728176c3c6431f8eeda4538dc37c865e2784f3a9e77d044f33e407797e1278a"
+  },
   "keccak256": [
     {
       "input": "please sign me!",
@@ -22,5 +26,103 @@
     "timestamp_ms": 1706000000000,
     "expected_hash": "49a567a359bf25d9652b24acc5567bc38c93139467c8fcf798f059ada585697e",
     "expected_signature": "dc7cede55d344fb59f10fa71b4915968a9d5c3f811faf7ddd834feb3cdce106539cd605b5a2d5fe35c21f27af92d01a68a06d6e813a613dac40e90a7a7a89181"
-  }
+  },
+  "request_signing_cases": [
+    {
+      "name": "text-body",
+      "body_hex": "74657374207265717565737420626f6479",
+      "timestamp_ms": 1706000000000,
+      "expected_hash": "49a567a359bf25d9652b24acc5567bc38c93139467c8fcf798f059ada585697e",
+      "expected_signature": "dc7cede55d344fb59f10fa71b4915968a9d5c3f811faf7ddd834feb3cdce106539cd605b5a2d5fe35c21f27af92d01a68a06d6e813a613dac40e90a7a7a89181",
+      "note": "The same body and timestamp as request_signing above, as hex."
+    },
+    {
+      "name": "binary-body",
+      "body_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+      "timestamp_ms": 1706000000000,
+      "expected_hash": "f3c18573988ebdefd8fb9990ee6b363fa6efeb79f23161624864782b16840944",
+      "expected_signature": "5e6f235933060c68ea535ca5931ddbfd8aa9cecee4126d68f591c7dd46f4e6be5278f60506e01d94c21ca360b3190ad514f3e9d429f87824690ab444d0f22c7c",
+      "note": "Every byte value 0x00-0xff: a body that is not text, which is what a protobuf request actually is."
+    },
+    {
+      "name": "grpc-framed-body",
+      "body_hex": "000000001174657374207265717565737420626f6479",
+      "timestamp_ms": 1706000000000,
+      "expected_hash": "5ad365069f66324357330680c9e171afb65dd129642192b638702671a5a8174e",
+      "expected_signature": "18f1c61c1838f554dc84f37f6c13edec2a7de3aeaddf7ddface5b4012f6b3f367889853c85a1e834049b6ca7611765af2a2d2cce80868dda13751607463a32fd",
+      "note": "The text body as it goes on the wire over gRPC: 0x00 || uint32be(length) || message. The network signs the framed bytes when it calls a provider over gRPC and the unframed bytes over Connect, so a provider has to verify against both."
+    },
+    {
+      "name": "empty-body",
+      "body_hex": "",
+      "timestamp_ms": 1706000000000,
+      "expected_hash": "205b5a560465f237a233995387de1c76ce3f5391fc531244d3e4c82bb3da665a",
+      "expected_signature": "5c515d14860086b51fb127e0e821e3db6019a107f2d4778e17081d6cff2718266ca29ec28569a32bfe5c6e94c70d199f7324cf7813ad3f040e58cbad052a7315",
+      "note": "A request with no body: the digest is over the timestamp alone."
+    },
+    {
+      "name": "leading-zero-s",
+      "body_hex": "74657374207265717565737420626f6479",
+      "timestamp_ms": 1706000000138,
+      "expected_hash": "b9934eeb180a75792a9a67eaf4396391623353bd7739a3cc061503d248db4666",
+      "expected_signature": "ff527c2d8f9d47907f5b7cb0507030bce77d8991db094c44addf52c4410f55fc00d7886b2f4dc76cb8fb1a8cf1df2aadca88dc1aada6badb6338f4a29005704b",
+      "note": "The s component starts with a zero byte. A signer that trims leading zeros instead of padding both components to a fixed 32 bytes fails this one and passes every other case."
+    }
+  ],
+  "signature_verification": [
+    {
+      "name": "valid",
+      "body_hex": "74657374207265717565737420626f6479",
+      "timestamp_ms": 1706000000000,
+      "public_key": "044fa1465c087aaf42e5ff707050b8f77d2ce92129c5f300686bdd3adfffe44567713bb7931632837c5268a832512e75599b6964f4484c9531c02e96d90384d9f0",
+      "signature": "dc7cede55d344fb59f10fa71b4915968a9d5c3f811faf7ddd834feb3cdce106539cd605b5a2d5fe35c21f27af92d01a68a06d6e813a613dac40e90a7a7a89181",
+      "valid": true,
+      "note": "The signature from the text-body case."
+    },
+    {
+      "name": "valid-65-byte-signature",
+      "body_hex": "74657374207265717565737420626f6479",
+      "timestamp_ms": 1706000000000,
+      "public_key": "044fa1465c087aaf42e5ff707050b8f77d2ce92129c5f300686bdd3adfffe44567713bb7931632837c5268a832512e75599b6964f4484c9531c02e96d90384d9f0",
+      "signature": "dc7cede55d344fb59f10fa71b4915968a9d5c3f811faf7ddd834feb3cdce106539cd605b5a2d5fe35c21f27af92d01a68a06d6e813a613dac40e90a7a7a8918101",
+      "valid": true,
+      "note": "The same signature with the recovery byte appended. Java and Go emit 65 bytes, Node emits 64, and every verifier takes either and ignores v."
+    },
+    {
+      "name": "wrong-key",
+      "body_hex": "74657374207265717565737420626f6479",
+      "timestamp_ms": 1706000000000,
+      "public_key": "044fa1465c087aaf42e5ff707050b8f77d2ce92129c5f300686bdd3adfffe44567713bb7931632837c5268a832512e75599b6964f4484c9531c02e96d90384d9f0",
+      "signature": "cf0928c28b0859999ecae51481a9733fe1beede0db3a46310fce89ee131a684314c12e2f193198c67bb010e04317fc39dba29f9279629a2ebc9d65ca84b7c0fe",
+      "valid": false,
+      "note": "Signed by impostor_keys, presented under the trusted public key."
+    },
+    {
+      "name": "tampered-body",
+      "body_hex": "74657374207265717565737420626f647a",
+      "timestamp_ms": 1706000000000,
+      "public_key": "044fa1465c087aaf42e5ff707050b8f77d2ce92129c5f300686bdd3adfffe44567713bb7931632837c5268a832512e75599b6964f4484c9531c02e96d90384d9f0",
+      "signature": "dc7cede55d344fb59f10fa71b4915968a9d5c3f811faf7ddd834feb3cdce106539cd605b5a2d5fe35c21f27af92d01a68a06d6e813a613dac40e90a7a7a89181",
+      "valid": false,
+      "note": "The last byte of the body changed after signing."
+    },
+    {
+      "name": "re-stamped-timestamp",
+      "body_hex": "74657374207265717565737420626f6479",
+      "timestamp_ms": 1706000005000,
+      "public_key": "044fa1465c087aaf42e5ff707050b8f77d2ce92129c5f300686bdd3adfffe44567713bb7931632837c5268a832512e75599b6964f4484c9531c02e96d90384d9f0",
+      "signature": "dc7cede55d344fb59f10fa71b4915968a9d5c3f811faf7ddd834feb3cdce106539cd605b5a2d5fe35c21f27af92d01a68a06d6e813a613dac40e90a7a7a89181",
+      "valid": false,
+      "note": "The valid signature replayed under a header five seconds later. The timestamp is inside the digest, so a captured request cannot be restamped."
+    },
+    {
+      "name": "zero-signature",
+      "body_hex": "74657374207265717565737420626f6479",
+      "timestamp_ms": 1706000000000,
+      "public_key": "044fa1465c087aaf42e5ff707050b8f77d2ce92129c5f300686bdd3adfffe44567713bb7931632837c5268a832512e75599b6964f4484c9531c02e96d90384d9f0",
+      "signature": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "valid": false,
+      "note": "r = s = 0. A verifier that skips the range check on r and s takes this one."
+    }
+  ]
 }

--- a/cross_test/test_vectors.json
+++ b/cross_test/test_vectors.json
@@ -86,7 +86,7 @@
       "public_key": "044fa1465c087aaf42e5ff707050b8f77d2ce92129c5f300686bdd3adfffe44567713bb7931632837c5268a832512e75599b6964f4484c9531c02e96d90384d9f0",
       "signature": "dc7cede55d344fb59f10fa71b4915968a9d5c3f811faf7ddd834feb3cdce106539cd605b5a2d5fe35c21f27af92d01a68a06d6e813a613dac40e90a7a7a8918101",
       "valid": true,
-      "note": "The same signature with the recovery byte appended. Java and Go emit 65 bytes, Node emits 64, and every verifier takes either and ignores v."
+      "note": "The same signature with recovery byte v=0x01 appended. Wire verifiers ignore v. Python's verify_signature helper recovers from it, so this fixture carries the v that recovers the trusted key."
     },
     {
       "name": "wrong-key",

--- a/csharp/sdk/T0.ProviderSdk.Tests/Crypto/CrossTestVectors.cs
+++ b/csharp/sdk/T0.ProviderSdk.Tests/Crypto/CrossTestVectors.cs
@@ -122,4 +122,63 @@ public class CrossTestVectors
         // Compare first 64 bytes (r+s) against the cross-language test vector
         Assert.Equal(expectedSignature, HexUtils.BytesToHex(result.Signature[..64]));
     }
+
+    /// <summary>
+    /// Bodies the string-valued request_signing block cannot express: binary, gRPC-framed,
+    /// empty, and one whose signature has a leading zero byte — the case a signer that trims
+    /// instead of padding to a fixed 32 bytes fails, and only that case.
+    /// </summary>
+    [Fact]
+    public void RequestSigningCases_ShouldMatchVectorBytes()
+    {
+        var keys = Vectors.RootElement.GetProperty("keys");
+        var signer = Signer.FromHex(keys.GetProperty("private_key").GetString()!);
+
+        var cases = Vectors.RootElement.GetProperty("request_signing_cases");
+        Assert.NotEmpty(cases.EnumerateArray());
+
+        foreach (var vec in cases.EnumerateArray())
+        {
+            var digest = RequestDigest(vec);
+            Assert.Equal(vec.GetProperty("expected_hash").GetString()!, HexUtils.BytesToHex(digest));
+
+            var result = signer.Sign(digest);
+            Assert.Equal(
+                vec.GetProperty("expected_signature").GetString()!,
+                HexUtils.BytesToHex(result.Signature[..64]));
+        }
+    }
+
+    /// <summary>
+    /// The presented-request cases, including the ones a provider has to refuse.
+    /// </summary>
+    [Fact]
+    public void SignatureVerification_ShouldMatchVectorOutcomes()
+    {
+        var cases = Vectors.RootElement.GetProperty("signature_verification");
+        Assert.NotEmpty(cases.EnumerateArray());
+
+        foreach (var vec in cases.EnumerateArray())
+        {
+            var publicKey = HexUtils.HexToBytes(vec.GetProperty("public_key").GetString()!);
+            var signature = HexUtils.HexToBytes(vec.GetProperty("signature").GetString()!);
+
+            Assert.Equal(
+                vec.GetProperty("valid").GetBoolean(),
+                SignatureVerifier.Verify(publicKey, RequestDigest(vec), signature));
+        }
+    }
+
+    /// <summary>
+    /// What the middleware hashes: the raw body with the little-endian timestamp appended.
+    /// </summary>
+    private static byte[] RequestDigest(JsonElement vec)
+    {
+        var body = HexUtils.HexToBytes(vec.GetProperty("body_hex").GetString()!);
+
+        var tsBytes = new byte[8];
+        BinaryPrimitives.WriteUInt64LittleEndian(tsBytes, (ulong)vec.GetProperty("timestamp_ms").GetInt64());
+
+        return Keccak256.Hash(body, tsBytes);
+    }
 }

--- a/go/crypto/cross_test.go
+++ b/go/crypto/cross_test.go
@@ -26,6 +26,34 @@ type testVectors struct {
 		ExpectedHash      string `json:"expected_hash"`
 		ExpectedSignature string `json:"expected_signature"`
 	} `json:"request_signing"`
+	RequestSigningCases []struct {
+		Name              string `json:"name"`
+		BodyHex           string `json:"body_hex"`
+		TimestampMs       uint64 `json:"timestamp_ms"`
+		ExpectedHash      string `json:"expected_hash"`
+		ExpectedSignature string `json:"expected_signature"`
+	} `json:"request_signing_cases"`
+	SignatureVerification []struct {
+		Name        string `json:"name"`
+		BodyHex     string `json:"body_hex"`
+		TimestampMs uint64 `json:"timestamp_ms"`
+		PublicKey   string `json:"public_key"`
+		Signature   string `json:"signature"`
+		Valid       bool   `json:"valid"`
+	} `json:"signature_verification"`
+}
+
+// requestDigest is what a provider hashes: the raw body with the little-endian
+// millisecond timestamp appended.
+func requestDigest(t *testing.T, bodyHex string, timestampMs uint64) []byte {
+	t.Helper()
+	body, err := hex.DecodeString(bodyHex)
+	require.NoError(t, err)
+
+	tsBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(tsBytes, timestampMs)
+
+	return crypto.LegacyKeccak256(append(body, tsBytes...))
 }
 
 func loadVectors(t *testing.T) testVectors {
@@ -101,4 +129,47 @@ func TestCrossVectors_RequestSignature(t *testing.T) {
 	require.NoError(t, err)
 	// Compare first 64 bytes (r+s) against the cross-language test vector
 	require.Equal(t, v.RequestSigning.ExpectedSignature, hex.EncodeToString(signature[:64]))
+}
+
+// Bodies that are not text: binary, gRPC-framed, empty, and one whose signature has a
+// leading zero byte. RFC 6979 makes the signature a function of key and digest alone, so
+// these are exact bytes every SDK has to reproduce, not round-trips.
+func TestCrossVectors_RequestSigningCases(t *testing.T) {
+	v := loadVectors(t)
+	require.NotEmpty(t, v.RequestSigningCases)
+
+	sign, err := crypto.NewSignerFromHex(v.Keys.PrivateKey)
+	require.NoError(t, err)
+
+	for _, tc := range v.RequestSigningCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			digest := requestDigest(t, tc.BodyHex, tc.TimestampMs)
+			require.Equal(t, tc.ExpectedHash, hex.EncodeToString(digest))
+
+			signature, _, err := sign(digest)
+			require.NoError(t, err)
+			require.Equal(t, tc.ExpectedSignature, hex.EncodeToString(signature[:64]))
+		})
+	}
+}
+
+// The presented-request cases, including the ones a provider has to refuse.
+func TestCrossVectors_SignatureVerification(t *testing.T) {
+	v := loadVectors(t)
+	require.NotEmpty(t, v.SignatureVerification)
+
+	for _, tc := range v.SignatureVerification {
+		t.Run(tc.Name, func(t *testing.T) {
+			pubKeyBytes, err := hex.DecodeString(tc.PublicKey)
+			require.NoError(t, err)
+			pubKey, err := crypto.GetPublicKeyFromBytes(pubKeyBytes)
+			require.NoError(t, err)
+
+			signature, err := hex.DecodeString(tc.Signature)
+			require.NoError(t, err)
+
+			digest := requestDigest(t, tc.BodyHex, tc.TimestampMs)
+			require.Equal(t, tc.Valid, crypto.VerifySignature(pubKey, digest, signature))
+		})
+	}
 }

--- a/java/sdk/src/test/java/network/t0/sdk/crypto/CrossVectorTest.java
+++ b/java/sdk/src/test/java/network/t0/sdk/crypto/CrossVectorTest.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -110,5 +111,63 @@ class CrossVectorTest {
         byte[] sig64 = new byte[64];
         System.arraycopy(result.getSignature(), 0, sig64, 0, 64);
         assertThat(HexUtils.bytesToHex(sig64)).isEqualTo(expectedSignature);
+    }
+
+    /**
+     * Bodies the string-valued request_signing block cannot express: binary, gRPC-framed
+     * (which is what this SDK verifies as its second path), empty, and one whose signature
+     * has a leading zero byte — the case a signer that trims instead of padding to a fixed
+     * 32 bytes fails, and only that case.
+     */
+    @Test
+    void requestSigningCases_shouldMatchVectorBytes() {
+        JsonObject keys = vectors.getAsJsonObject("keys");
+        Signer signer = Signer.fromHex(keys.get("private_key").getAsString());
+
+        JsonArray cases = vectors.getAsJsonArray("request_signing_cases");
+        assertThat(cases).isNotEmpty();
+
+        for (var element : cases) {
+            JsonObject vec = element.getAsJsonObject();
+            String name = vec.get("name").getAsString();
+            byte[] digest = requestDigest(vec);
+
+            assertThat(HexUtils.bytesToHex(digest))
+                    .as("digest for %s", name)
+                    .isEqualTo(vec.get("expected_hash").getAsString());
+
+            byte[] sig64 = Arrays.copyOf(signer.sign(digest).getSignature(), 64);
+            assertThat(HexUtils.bytesToHex(sig64))
+                    .as("signature for %s", name)
+                    .isEqualTo(vec.get("expected_signature").getAsString());
+        }
+    }
+
+    /** The presented-request cases, including the ones a provider has to refuse. */
+    @Test
+    void signatureVerification_shouldMatchVectorOutcomes() {
+        JsonArray cases = vectors.getAsJsonArray("signature_verification");
+        assertThat(cases).isNotEmpty();
+
+        for (var element : cases) {
+            JsonObject vec = element.getAsJsonObject();
+            byte[] publicKey = HexUtils.hexToBytes(vec.get("public_key").getAsString());
+            byte[] signature = HexUtils.hexToBytes(vec.get("signature").getAsString());
+
+            assertThat(SignatureVerifier.verify(publicKey, requestDigest(vec), signature))
+                    .as("%s: %s", vec.get("name").getAsString(), vec.get("note").getAsString())
+                    .isEqualTo(vec.get("valid").getAsBoolean());
+        }
+    }
+
+    /** What a provider hashes: the raw body with the little-endian timestamp appended. */
+    private static byte[] requestDigest(JsonObject vec) {
+        byte[] body = HexUtils.hexToBytes(vec.get("body_hex").getAsString());
+        byte[] tsBytes = ByteBuffer.allocate(8)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putLong(vec.get("timestamp_ms").getAsLong())
+                .array();
+
+        return Keccak256.hash(body, tsBytes);
     }
 }

--- a/node/sdk/test/crypto.test.ts
+++ b/node/sdk/test/crypto.test.ts
@@ -173,3 +173,56 @@ describe('Request signing', () => {
     nodeAssert.equal(sig.signature.subarray(0, 64).toString('hex'), expected_signature);
   });
 });
+
+// What the middleware hashes: the raw body with the little-endian millisecond timestamp
+// appended. body_hex carries the bytes, so a body can be binary, framed or empty.
+function requestDigest(bodyHex: string, timestampMs: number): Buffer {
+  const tsBuf = Buffer.alloc(8);
+  tsBuf.writeBigUInt64LE(BigInt(timestampMs));
+
+  return Buffer.from(
+    keccak_256.create()
+      .update(Buffer.from(bodyHex, 'hex'))
+      .update(tsBuf)
+      .digest()
+  );
+}
+
+describe('Request signing cases', () => {
+  // Bodies the string-valued request_signing block cannot express: binary, gRPC-framed,
+  // empty, and one whose signature has a leading zero byte — the case a signer that trims
+  // instead of padding to 32 bytes fails, and only that case.
+  for (const vec of vectors.request_signing_cases) {
+    it(`${vec.name} hashes and signs to the vector bytes`, async () => {
+      const digest = requestDigest(vec.body_hex, vec.timestamp_ms);
+      nodeAssert.equal(digest.toString('hex'), vec.expected_hash);
+
+      const signer = CreateSigner(vectors.keys.private_key);
+      const sig = await signer(digest);
+      nodeAssert.equal(sig.signature.subarray(0, 64).toString('hex'), vec.expected_signature);
+    });
+  }
+});
+
+describe('Signature verification cases', () => {
+  for (const vec of vectors.signature_verification) {
+    it(`${vec.name} verifies: ${vec.valid}`, () => {
+      const digest = requestDigest(vec.body_hex, vec.timestamp_ms);
+      const publicKey = Buffer.from(vec.public_key, 'hex');
+
+      // service.ts truncates a 65-byte signature before verifying, and treats a throw from
+      // noble the same as a false — both end as Unauthenticated. Mirror that here.
+      const signature = Buffer.from(vec.signature, 'hex');
+      const sig64 = signature.length === 65 ? signature.subarray(0, 64) : signature;
+
+      let valid = false;
+      try {
+        valid = secp256k1.verify(sig64, digest, publicKey, { prehash: false });
+      } catch {
+        valid = false;
+      }
+
+      nodeAssert.equal(valid, vec.valid);
+    });
+  }
+});

--- a/python/sdk/tests/crypto/test_cross_vectors.py
+++ b/python/sdk/tests/crypto/test_cross_vectors.py
@@ -65,3 +65,42 @@ class TestCrossVectorsRequestSignature:
         sig, _ = sign_fn(digest)
         # Compare first 64 bytes (r+s) against the cross-language test vector
         assert sig[:64].hex() == rs["expected_signature"]
+
+
+def _request_digest(vec) -> bytes:
+    """What the middleware hashes: raw body, little-endian millisecond timestamp appended."""
+    body = bytes.fromhex(vec["body_hex"])
+    ts_bytes = struct.pack("<Q", vec["timestamp_ms"])
+    return legacy_keccak256(body + ts_bytes)
+
+
+class TestCrossVectorsRequestSigningCases:
+    """Bodies the string-valued request_signing block cannot express: binary, gRPC-framed,
+    empty, and one whose signature has a leading zero byte — the case a signer that trims
+    instead of padding to a fixed 32 bytes fails, and only that case."""
+
+    def test_all_cases(self):
+        cases = VECTORS["request_signing_cases"]
+        assert cases
+
+        sign_fn = new_signer_from_hex(VECTORS["keys"]["private_key"])
+        for vec in cases:
+            digest = _request_digest(vec)
+            assert digest.hex() == vec["expected_hash"], f"digest for {vec['name']}"
+
+            sig, _ = sign_fn(digest)
+            assert sig[:64].hex() == vec["expected_signature"], f"signature for {vec['name']}"
+
+
+class TestCrossVectorsSignatureVerification:
+    """The presented-request cases, including the ones a provider has to refuse."""
+
+    def test_all_cases(self):
+        cases = VECTORS["signature_verification"]
+        assert cases
+
+        for vec in cases:
+            public_key = public_key_from_bytes(bytes.fromhex(vec["public_key"]))
+            signature = bytes.fromhex(vec["signature"])
+            result = verify_signature(public_key, _request_digest(vec), signature)
+            assert result == vec["valid"], f"{vec['name']}: {vec['note']}"


### PR DESCRIPTION
The shared fixture had one signing case — a text body, one timestamp, one signature — and nothing that said what a verifier has to refuse. Real requests are none of those things: a protobuf body is binary, a gRPC body carries a 5-byte frame the Connect one does not, and a request with no fields set has no body at all.

## `request_signing_cases`

Signing cases with `body_hex` instead of a string body, so the preimage is exact rather than whatever the reader's language does to text:

| Case | Body |
|---|---|
| `text-body` | the same body and timestamp as the existing `request_signing` block, as hex |
| `binary-body` | every byte value `0x00`–`0xff` |
| `grpc-framed-body` | `0x00` + `uint32be(length)` + message — what the network signs when it calls a provider over gRPC, where Connect callers sign the message alone |
| `empty-body` | no body: the digest is over the timestamp alone |
| `leading-zero-s` | its `s` starts with a zero byte |

`text-body` reproduces the existing `request_signing` block byte for byte, which is what keeps the two from drifting apart.

`leading-zero-s` exists for padding alone. A signer that trims leading zeros instead of padding both components to a fixed 32 bytes passes every other case in this file and fails that one — it is the classic cross-language ECDSA bug and nothing here caught it before.

## `signature_verification`

The other half: a presented request, and whether it verifies.

| Case | Verifies |
|---|---|
| `valid` | yes |
| `valid-65-byte-signature` | yes — the same signature with the recovery byte appended |
| `wrong-key` | no — signed by `impostor_keys`, presented under the trusted key |
| `tampered-body` | no — the body edited after signing |
| `re-stamped-timestamp` | no — the valid signature replayed under a header five seconds later |
| `zero-signature` | no — `r = s = 0`, which only fails if the verifier range-checks `r` and `s` |

`re-stamped-timestamp` is what makes the timestamp's place in the digest testable: a captured request cannot be given a fresh timestamp without breaking its signature.

## What is deliberately not here

The 60-second window. Whether a request is *accepted* also depends on its timestamp being close to the verifier's clock — but that is a clock only the verifier can see, so pinning it in a shared fixture means pinning one machine's clock in five languages. It belongs in each SDK's middleware tests. The fixture answers the question that has one right answer everywhere: does this signature verify.

## Verification

All five suites read the new arrays and pass, across four curve libraries (BouncyCastle in Java and C#, noble in Node, dcrd/btcec in Go, coincurve in Python):

```
cd go && go test ./crypto/... -run Cross     # 11 new subtests
cd node/sdk && npm test                       # 43 tests
cd java && ./gradlew :sdk:test --tests "*CrossVector*"
cd python && uv run pytest sdk/tests/crypto/test_cross_vectors.py -v
cd csharp && dotnet test --filter "FullyQualifiedName~CrossTestVectors"
```

One portability note, written down in the new `cross_test/README.md`: a 65-byte signature has to carry the correct recovery byte. Go, Java, Node and C# ignore `v`, but Python verifies by recovering the key from the signature, so a wrong `v` fails there and nowhere else.

## Where this came from

Writing golden vectors for the pay SDK (t-0-network/usdt-pay-sdk#5) meant deriving the scheme from all five implementations and running them against each other. That work produced these cases; this is where they belong, next to the implementations they cover, rather than in a second fixture two suites read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
