### PR TITLE
Add the go.sum entry the 1.1.26 bump left out

### DIFF
--- a/go/starter/template/go.sum
+++ b/go/starter/template/go.sum
@@ -36,6 +36,8 @@ github.com/rodaine/protogofakeit v0.1.1 h1:ZKouljuRM3A+TArppfBqnH8tGZHOwM/pjvtXe
 github.com/rodaine/protogofakeit v0.1.1/go.mod h1:pXn/AstBYMaSfc1/RqH3N82pBuxtWgejz1AlYpY1mI0=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/t-0-network/provider-sdk/go v1.1.26 h1:u4VZvb8K/KlsYlogDOnb6md+GEbBpjh26nU9lmPIV7U=
+github.com/t-0-network/provider-sdk/go v1.1.26/go.mod h1:7CMyIzIjpOgrj8qhV7eUqtmP1zcl3uVDlxsn0Hxt194=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=


### PR DESCRIPTION
`go build ./...` in `go/starter/template` fails on master:

```
missing go.sum entry needed to verify package github.com/t-0-network/provider-sdk/go/starter/template/cmd is provided by exactly one module; to add:
	go mod download github.com/t-0-network/provider-sdk/go
```

`Release 1.1.26` moved the template's `go.mod` onto `provider-sdk/go v1.1.26` and did not add the matching `go.sum` lines. CI builds with `-mod=readonly`, so it cannot add them itself and the Go job fails on every PR — this is the same failure #200 fixed for an earlier release.

The fix is the two lines that building the template against the published module produces. Same shape as #200; the release workflow is what keeps reintroducing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)