### PR TITLE
Publish the Node starter after the SDK, not beside it

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -243,7 +243,12 @@ jobs:
 
   publish-node-starter:
     name: Publish Node Starter
-    needs: [build-go, build-node, build-java, build-python, build-csharp]
+    # publish-node-sdk is in this list on purpose. The starter ships the
+    # template, whose package.json pins @t-0/provider-sdk at ^<this version>,
+    # and the scaffolder runs `npm install` in the generated project right
+    # away. If the starter reached npm first, anyone scaffolding in that window
+    # would be installing against an SDK version that is not published yet.
+    needs: [build-go, build-node, build-java, build-python, build-csharp, publish-node-sdk]
     # Must use github-hosted runner: npm --provenance requires it (Blacksmith = "self-hosted", rejected by npm)
     runs-on: ubuntu-latest
     permissions:

--- a/docs/HEALTH_SERVICE.md
+++ b/docs/HEALTH_SERVICE.md
@@ -18,7 +18,7 @@ There is no opt-out flag, and there should not be one. The Network needs a reach
 
 ## Every ecosystem takes this as a dependency — except Node, which vendors it
 
-The rule is that `health.proto` is not vendored and no copy is generated into an SDK artifact: each ecosystem consumes a published package, so nothing here puts a schema on a customer's classpath that they could conflict with.
+The rule is that each ecosystem consumes a published `grpc.health.v1` package rather than a copy generated into its SDK artifact, so nothing here puts a schema on a customer's classpath that they could conflict with. Node is the one exception, for the reason below the table.
 
 | Ecosystem | Dependency | Registry |
 |---|---|---|
@@ -53,7 +53,7 @@ The registered set is frozen when the server is constructed. Nothing about it is
 
 ```
 t0-sdk-ecosystem: go | node | python | java | csharp
-t0-sdk-version:   1.1.26
+t0-sdk-version:   <the SDK's own version, e.g. 1.1.28>
 ```
 
 Set on the `Check` response and on nothing else. They are headers rather than fields because `HealthCheckResponse` has exactly one field and `Check` names its service in the *request* — the contract has nowhere to carry the identity of the SDK answering. Scoping them to this one handler is what makes headers acceptable: every callback the customer actually serves is untouched.
@@ -93,8 +93,6 @@ How each ecosystem scopes the identity headers to this handler:
 - **C#** — `context.WriteResponseHeadersAsync(...)` inside the `Check` override.
 
 **Java:** the health service is appended inside `buildGrpcServer()` and never into `Builder.services`, so `Builder.build()`'s "at least one service must be added with `withService()`" check still catches a customer who forgot to register their own.
-
-**Node:** `health.ts` used to need a cast because the BSR package's published `.d.ts` lost its type brands through `ServiceImpl`'s generics, widening the request to `Message<string>`. Vendoring the stub as a first-party `.ts` removed that; the request types check without help.
 
 **Python:** connect-python publishes no health bindings, so `health.py` assembles the ASGI/WSGI applications from `Endpoint` directly. Only the messages come from the package.
 

--- a/node/sdk/src/service/health_pb.ts
+++ b/node/sdk/src/service/health_pb.ts
@@ -5,12 +5,15 @@
 //           buf.gen.yaml pin -- plugin and @bufbuild/protobuf runtime must
 //           agree on major).
 //
-// Regenerate by overwriting this file:
+// Regenerate with the following, which keeps this header and replaces
+// everything from the gRPC copyright line down. Do not just `mv` the generated
+// file over this one -- that would delete these instructions along with it.
 //
 //   cd node/sdk
 //   buf generate buf.build/grpc/grpc --path grpc/health/v1/health.proto \
 //     --template '{"version":"v2","plugins":[{"remote":"buf.build/bufbuild/es:v2.12.0","out":"gen-health","opt":["target=ts","import_extension=js"]}]}'
-//   mv gen-health/grpc/health/v1/health_pb.ts src/service/health_pb.ts
+//   sed '/^\/\/ Copyright 2015 The gRPC Authors/,$d' src/service/health_pb.ts > gen-health/header
+//   cat gen-health/header gen-health/grpc/health/v1/health_pb.ts > src/service/health_pb.ts
 //   rm -rf gen-health
 //
 // Vendored rather than depended on: the equivalent package


### PR DESCRIPTION
A Codex review of #211 found one consumer-visible race and three documentation defects that PR introduced or left behind.

## The race

`publish-node-starter` and `publish-node-sdk` both declared `needs: [build-*]` and nothing else, so they ran concurrently. The starter ships `node/starter/template`, whose `package.json` pins `@t-0/provider-sdk` at `^<this version>`, and the scaffolder runs `npm install` in the generated project right away. If the starter reached npm first, anyone scaffolding in that window installed against an SDK version that was not published yet.

Adding `publish-node-sdk` to the starter's `needs` closes it. Both jobs still gate on all five builds.

## Documentation defects from #211

- **A false claim, deleted.** `HEALTH_SERVICE.md` said Node needed the old cast because the BSR package's published `.d.ts` lost its type brands through `ServiceImpl`'s generics. That is not true — the declaration keeps `HealthCheckRequestSchema: GenMessage<HealthCheckRequest>` and uses it as `Health.check.input`, so the request was never widened and the cast was unnecessary even before vendoring. The paragraph also explained a cast that no longer exists.
- **A self-contradiction.** The section opener asserted no schema copy is generated into any SDK artifact, one paragraph above the table row stating Node vendors one.
- **A stale literal.** The identity-header example showed `t0-sdk-version: 1.1.26`; it now names the field instead of pinning a number that drifts every release.

## The regeneration instructions destroyed themselves

The header in `health_pb.ts` told you to `mv` the generated file over it — which deletes the header, including those instructions. It now preserves the header and replaces everything from the gRPC copyright line down.

Verified by actually running the new procedure: the file comes back byte-identical to what is committed.

## Checks

`npm run build` and `npm test` in `node/sdk` — 43/43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)