### PR TITLE
chore(deps): bump grpcVersion from 1.81.0 to 1.82.0 in /java

### DIFF
--- a/java/sdk/build.gradle.kts
+++ b/java/sdk/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.gradleup.nmcp")
 }
 
-val grpcVersion = "1.81.0"
+val grpcVersion = "1.82.0"
 val protobufVersion = "4.35.1"
 val bouncyCastleVersion = "1.84"
 


### PR DESCRIPTION
## Summary
- Bump gRPC from 1.81.0 to 1.82.0 (minor version)
- Replaces Dependabot PR #160 (branch was lost during rebase)
- Crypto audit: safe — signing path uses raw bytes via `ByteArrayMarshaller`, not gRPC serialization

## Test plan
- [ ] Java CI passes (all interceptor + integration tests)
- [ ] All other CI jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpYFy5yLUnizxNjE56nYzj