### PR TITLE
chore(deps): bump @connectrpc/* 2.1.1 → 2.1.2 + add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/go"
     schedule:
       interval: "weekly"
+    groups:
+      connectrpc:
+        patterns:
+          - "connectrpc.com/*"
+      google-golang:
+        patterns:
+          - "google.golang.org/*"
 
   - package-ecosystem: "gomod"
     directory: "/go/starter"
@@ -19,11 +26,22 @@ updates:
     directory: "/go/starter/template"
     schedule:
       interval: "weekly"
+    groups:
+      connectrpc:
+        patterns:
+          - "connectrpc.com/*"
+      google-golang:
+        patterns:
+          - "google.golang.org/*"
 
   - package-ecosystem: "npm"
     directory: "/node/sdk"
     schedule:
       interval: "weekly"
+    groups:
+      connectrpc:
+        patterns:
+          - "@connectrpc/*"
 
   - package-ecosystem: "npm"
     directory: "/node/starter"
@@ -39,3 +57,12 @@ updates:
     directory: "/java"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "nuget"
+    directory: "/csharp"
+    schedule:
+      interval: "weekly"
+    groups:
+      grpc:
+        patterns:
+          - "Grpc.*"

--- a/node/sdk/package-lock.json
+++ b/node/sdk/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
         "@bufbuild/protovalidate": "^1.2.0",
-        "@connectrpc/connect": "^2.1.1",
-        "@connectrpc/connect-node": "^2.1.1",
-        "@connectrpc/connect-web": "^2.1.1",
+        "@connectrpc/connect": "^2.1.2",
+        "@connectrpc/connect-node": "^2.1.2",
+        "@connectrpc/connect-web": "^2.1.2",
         "@connectrpc/validate": "^0.2.0",
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0"
@@ -116,35 +116,35 @@
       }
     },
     "node_modules/@connectrpc/connect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
-      "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
     },
     "node_modules/@connectrpc/connect-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.1.tgz",
-      "integrity": "sha512-s3TfsI1XF+n+1z6MBS9rTnFsxxR4Rw5wmdEnkQINli81ESGxcsfaEet8duzq8LVuuCupmhUsgpRo0Nv9pZkufg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
+      "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.1"
+        "@connectrpc/connect": "2.1.2"
       }
     },
     "node_modules/@connectrpc/connect-web": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.1.tgz",
-      "integrity": "sha512-J8317Q2MaFRCT1jzVR1o06bZhDIBmU0UAzWx6xOIXzOq8+k71/+k7MUF7AwcBUX+34WIvbm5syRgC5HXQA8fOg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.2.tgz",
+      "integrity": "sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.1"
+        "@connectrpc/connect": "2.1.2"
       }
     },
     "node_modules/@connectrpc/validate": {

--- a/node/sdk/package.json
+++ b/node/sdk/package.json
@@ -30,9 +30,9 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.12.0",
     "@bufbuild/protovalidate": "^1.2.0",
-    "@connectrpc/connect": "^2.1.1",
-    "@connectrpc/connect-node": "^2.1.1",
-    "@connectrpc/connect-web": "^2.1.1",
+    "@connectrpc/connect": "^2.1.2",
+    "@connectrpc/connect-node": "^2.1.2",
+    "@connectrpc/connect-web": "^2.1.2",
     "@connectrpc/validate": "^0.2.0",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0"


### PR DESCRIPTION
## Summary

- **Bump @connectrpc/connect, connect-node, connect-web** from 2.1.1 → 2.1.2 in `node/sdk` — these packages declare exact peer deps on each other, so bumping one alone breaks `npm ci` with `ERESOLVE`
- **Add dependency grouping** to `dependabot.yml` to prevent this class of issue going forward:
  - `npm /node/sdk`: group `@connectrpc/*`
  - `gomod /go` and `/go/starter/template`: group `connectrpc.com/*` and `google.golang.org/*`
  - Add `nuget` ecosystem for `/csharp` with `Grpc.*` group

Supersedes #159, #164, #174.

## Test plan

- [x] `cd node/sdk && npm ci` — no ERESOLVE or lockfile mismatch
- [x] `cd node/sdk && npm run build` — compiles cleanly
- [x] `cd node/sdk && npm test` — 49/49 pass
- [ ] CI passes on the combined PR (all 5 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzQtCkxhFtGQUVRqmFBckr