### PR TITLE
fix(ci): make Go template build hermetic with sumtool

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -57,6 +57,8 @@ jobs:
       - name: Build starter template
         working-directory: go
         run: |
-          go work init . ./starter ./starter/template
-          cd starter/template && go build ./...
-          cd ../.. && rm -f go.work go.work.sum
+          VERSION=$(grep 'github.com/t-0-network/provider-sdk/go v' starter/template/go.mod | awk '{print $2}')
+          PROXY_DIR="${RUNNER_TEMP}/goproxy"
+          go -C ../.github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "${VERSION}" "${PROXY_DIR}"
+          cd starter/template
+          GOPROXY="file://${PROXY_DIR},https://proxy.golang.org,direct" GONOSUMDB="github.com/t-0-network" go build ./...

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -176,32 +176,16 @@ jobs:
           git tag "go/starter/template/v${VERSION}"
           git push origin "go/v${VERSION}" "go/starter/v${VERSION}" "go/starter/template/v${VERSION}"
 
-      # A freshly pushed tag can take a moment to become visible to proxy.golang.org, so retry
-      # each module a few times before failing.
-      - name: Request GOPROXY update
+      # Verify the template builds against the tagged SDK source using a local
+      # file:// GOPROXY (same sumtool technique as release.yaml and ci-go.yaml).
+      # -mod=readonly so a missing or wrong go.sum line fails the build.
+      - name: Verify starter template against the published SDK
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
-          warm() {
-            for attempt in 1 2 3 4 5; do
-              if GOPROXY=proxy.golang.org go list -m "$1@v${VERSION}"; then
-                return 0
-              fi
-              echo "proxy not ready for $1@v${VERSION} (attempt ${attempt}/5); retrying in 10s..."
-              sleep 10
-            done
-            echo "::error::proxy.golang.org did not serve $1@v${VERSION} after 5 attempts"
-            return 1
-          }
-          warm "github.com/t-0-network/provider-sdk/go"
-          warm "github.com/t-0-network/provider-sdk/go/starter"
-          warm "github.com/t-0-network/provider-sdk/go/starter/template"
-
-      # Checks the go.sum entry release.yaml precomputed against the module the proxy now
-      # serves. -mod=readonly fails on a missing line as well as a wrong hash.
-      # See docs/RELEASE_AND_PUBLISH.md, `publish-go`.
-      - name: Verify starter template against the published SDK
-        working-directory: go/starter/template
-        run: go build -mod=readonly ./...
+          PROXY_DIR="${RUNNER_TEMP}/goproxy"
+          go -C .github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "v${VERSION}" "${PROXY_DIR}"
+          cd go/starter/template
+          GOPROXY="file://${PROXY_DIR},https://proxy.golang.org,direct" GONOSUMDB="github.com/t-0-network" go build -mod=readonly ./...
 
   publish-node-sdk:
     name: Publish Node SDK


### PR DESCRIPTION
## Summary

- **ci-go.yaml**: Replace `go work init` with sumtool-based `file://` GOPROXY for the template build step. The workspace approach was not hermetic — on release commits, Go still queried `proxy.golang.org` for `v1.1.29` before `publish-go` pushed the `go/*` tags, causing a 404 that got negative-cached and broke both CI and publish.
- **publish.yaml**: Remove the `go list` warm-up loop (5×10s) entirely. Replace with the same sumtool `file://` GOPROXY for the post-publish verification — no proxy queries, no sleep/retry, no negative-cache risk.

Both steps now use the same pattern as `release.yaml`.

## Evidence from v1.1.29 failure

CI ([run 32980063211](https://github.com/t-0-network/provider-sdk/actions/runs/32980063211)) at 14:25:03:
```
github.com/t-0-network/provider-sdk/go@v1.1.29: reading ...go.mod at revision go/v1.1.29: unknown revision go/v1.1.29
```

Publish ([run 32980062490](https://github.com/t-0-network/provider-sdk/actions/runs/32980062490)) at 14:26:10–14:27:00: all 5 warm-up attempts hit the same cached 404.

## Test plan

- [ ] CI passes on this branch (the template build step uses sumtool)
- [ ] Next release validates the publish-go verification step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149AGZBFwvTZRazPrENqJrD