### PR TITLE
docs: state Protobuf as canonical wire format, add de/serialization example

### DIFF
--- a/node/sdk/README.md
+++ b/node/sdk/README.md
@@ -1,6 +1,6 @@
 # T-0 Provider SDK -- TypeScript
 
-TypeScript SDK for building provider integrations with the T-0 Network. Handles secp256k1 cryptographic signing, signature verification, and provides typed ConnectRPC clients for all T-0 Network APIs.
+TypeScript SDK for building provider integrations with the T-0 Network. All communication uses **Protobuf-encoded ConnectRPC** — secp256k1-signed requests, verified inbound calls, and typed clients for all T-0 Network APIs.
 
 ## Quick Start
 
@@ -94,6 +94,8 @@ function handleRequest(rawBody: Uint8Array, headers: Record<string, string>) {
   // Request is authenticated — parse the protobuf body and handle it
 }
 ```
+
+The transport is ConnectRPC with Protobuf encoding: all request and response payloads are Protobuf-serialized. Error responses follow the [Connect error spec](https://connectrpc.com/docs/protocol#error-end-stream).
 
 The lower-level primitives are also exported individually: `verifySignature`, `computeDigest`, `keccak256`, `parsePublicKey`, `publicKeysEqual`.
 

--- a/node/sdk/README.md
+++ b/node/sdk/README.md
@@ -1,6 +1,6 @@
 # T-0 Provider SDK -- TypeScript
 
-TypeScript SDK for building provider integrations with the T-0 Network. Handles secp256k1 cryptographic signing, signature verification, and provides typed ConnectRPC clients for all T-0 Network APIs. All request and response payloads are **Protobuf-encoded**.
+TypeScript SDK for building provider integrations with the T-0 Network. Handles secp256k1 cryptographic signing, signature verification, and provides typed clients for all T-0 Network APIs. All request and response payloads are **Protobuf-encoded**.
 
 ## Quick Start
 
@@ -62,7 +62,7 @@ const server = http.createServer(
 server.listen(3000);
 ```
 
-The middleware chain: `signatureValidation` captures raw request bytes for hashing, `nodeAdapter` bridges ConnectRPC to Node.js HTTP, and `createService` registers your handlers with signature verification.
+The middleware chain: `signatureValidation` captures raw request bytes for hashing, `nodeAdapter` bridges the RPC transport to Node.js HTTP, and `createService` registers your handlers with signature verification.
 
 ### Standalone Signature Verification
 

--- a/node/sdk/README.md
+++ b/node/sdk/README.md
@@ -1,6 +1,6 @@
 # T-0 Provider SDK -- TypeScript
 
-TypeScript SDK for building provider integrations with the T-0 Network. All communication uses **Protobuf-encoded ConnectRPC** — secp256k1-signed requests, verified inbound calls, and typed clients for all T-0 Network APIs.
+TypeScript SDK for building provider integrations with the T-0 Network. Handles secp256k1 cryptographic signing, signature verification, and provides typed ConnectRPC clients for all T-0 Network APIs. All request and response payloads are **Protobuf-encoded**.
 
 ## Quick Start
 
@@ -69,7 +69,8 @@ The middleware chain: `signatureValidation` captures raw request bytes for hashi
 For frameworks that don't use Node's `http.createServer` (Effect, Koa, Fastify, etc.), use `createRequestVerifier` to verify inbound requests with just the raw body bytes and headers:
 
 ```ts
-import { createRequestVerifier, parsePublicKey } from "@t-0/provider-sdk";
+import { fromBinary, toBinary } from "@bufbuild/protobuf";
+import { createRequestVerifier, PayoutRequestSchema, PayoutResponseSchema } from "@t-0/provider-sdk";
 
 const verify = createRequestVerifier({
   networkPublicKey: process.env.NETWORK_PUBLIC_KEY!,
@@ -91,11 +92,18 @@ function handleRequest(rawBody: Uint8Array, headers: Record<string, string>) {
     return errorResponse(result.reason);
   }
 
-  // Request is authenticated — parse the protobuf body and handle it
+  // Deserialize the Protobuf request (same raw bytes you verified)
+  const request = fromBinary(PayoutRequestSchema, rawBody);
+  const response = handlePayout(request);
+
+  // Serialize the Protobuf response
+  return successResponse(toBinary(PayoutResponseSchema, response), {
+    "content-type": "application/proto",
+  });
 }
 ```
 
-The transport is ConnectRPC with Protobuf encoding: all request and response payloads are Protobuf-serialized. Error responses follow the [Connect error spec](https://connectrpc.com/docs/protocol#error-end-stream).
+All request and response payloads are Protobuf-encoded — deserialize with `fromBinary()`, serialize with `toBinary()` (both from `@bufbuild/protobuf`).
 
 The lower-level primitives are also exported individually: `verifySignature`, `computeDigest`, `keccak256`, `parsePublicKey`, `publicKeysEqual`.
 


### PR DESCRIPTION
## Summary
- Adds "All request and response payloads are **Protobuf-encoded**" to the SDK intro line
- Expands the standalone verification example with `fromBinary()`/`toBinary()` showing full request deserialization and response serialization
- Adds a one-line note after the example: all payloads are Protobuf-encoded
- Replaces PR #252 (closed) — updated to remove ConnectRPC leak per review feedback

Companion to t-0-network/usdt-pay-sdk#33 (purging JSON-as-wire-format from docs).

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `PayoutRequestSchema` and `PayoutResponseSchema` are valid exports from `@t-0/provider-sdk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBPRWQrkcLto5y9L579uo2