### PR TITLE
fix(ci): remove proxy.golang.org from Go workflow steps

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -59,6 +59,6 @@ jobs:
         run: |
           VERSION=$(grep 'github.com/t-0-network/provider-sdk/go v' starter/template/go.mod | awk '{print $2}')
           PROXY_DIR="${RUNNER_TEMP}/goproxy"
-          go -C ../.github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "${VERSION}" "${PROXY_DIR}"
+          GOPROXY=direct go -C ../.github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "${VERSION}" "${PROXY_DIR}"
           cd starter/template
-          GOPROXY="file://${PROXY_DIR},https://proxy.golang.org,direct" GONOSUMDB="github.com/t-0-network" go build ./...
+          GOPROXY="file://${PROXY_DIR},direct" GONOSUMDB="github.com/t-0-network" go build ./...

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -183,9 +183,9 @@ jobs:
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
           PROXY_DIR="${RUNNER_TEMP}/goproxy"
-          go -C .github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "v${VERSION}" "${PROXY_DIR}"
+          GOPROXY=direct go -C .github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "v${VERSION}" "${PROXY_DIR}"
           cd go/starter/template
-          GOPROXY="file://${PROXY_DIR},https://proxy.golang.org,direct" GONOSUMDB="github.com/t-0-network" go build -mod=readonly ./...
+          GOPROXY="file://${PROXY_DIR},direct" GONOSUMDB="github.com/t-0-network" go build -mod=readonly ./...
 
   publish-node-sdk:
     name: Publish Node SDK

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -254,10 +254,10 @@ jobs:
           # sumtool walks the filesystem; the tag will only carry tracked files.
           test -z "$(git status --porcelain --ignored -- go | grep -E '^(\?\?|!!)')" \
             || { echo "::error::untracked/ignored files under go/ would poison the module hash"; exit 1; }
-          go -C .github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "v${VERSION}" "${PROXY_DIR}"
+          GOPROXY=direct go -C .github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "v${VERSION}" "${PROXY_DIR}"
           cd go/starter/template
           go mod edit -require "github.com/t-0-network/provider-sdk/go@v${VERSION}"
-          export GOPROXY="file://${PROXY_DIR},https://proxy.golang.org,direct"
+          export GOPROXY="file://${PROXY_DIR},direct"
           export GONOSUMDB="github.com/t-0-network"
           go mod tidy
           go build ./...


### PR DESCRIPTION
## Summary

- Remove `https://proxy.golang.org` from the GOPROXY chain in all three Go workflow steps (ci-go, release, publish)
- Change from `file://${PROXY_DIR},https://proxy.golang.org,direct` to `file://${PROXY_DIR},direct`
- Prefix sumtool `go run` invocations with `GOPROXY=direct` so the sumtool's own deps also bypass the proxy

**How it works:**
- SDK module → served from local sumtool `file://` proxy (from disk, no network)
- Third-party deps → fetched directly from VCS repos (`direct`), no proxy involved
- `sum.golang.org` still verifies third-party checksums during `go mod tidy` (race-free — those deps are published)

**Why it's reliable:** `direct` does `git ls-remote` / `git clone` against source repos. There is no CDN cache layer to negative-cache a 404. The failure mode that broke v1.1.29 publish (proxy queried 78ms after tag push, 404 negative-cached for 30 min) is structurally impossible.

## Test plan

- [x] Cold-cache local build with `GOPROXY="file://${PROXY_DIR},direct"` — all 21 deps resolved via VCS
- [x] Cold-cache build with **unpublished version v1.99.99** (exists nowhere except local file:// proxy) — both `go mod tidy` and `go build -mod=readonly` succeeded
- [x] Verified zero `proxy.golang.org` calls via `go mod download -x` output
- [x] Verified all custom-domain modules work with `direct`: `buf.build`, `cel.dev`, `connectrpc.com`, `go.yaml.in`
- [x] `grep -rn proxy.golang.org .github/` returns zero results
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NDifVcEj9iR8eGfvFzS8r