### PR TITLE
feat(node): export rejectRequest and createHandler

### DIFF
--- a/node/sdk/README.md
+++ b/node/sdk/README.md
@@ -27,9 +27,7 @@ Implement the `ProviderService` interface to receive callbacks from the T-0 Netw
 ```ts
 import http from "node:http";
 import {
-  createService,
-  nodeAdapter,
-  signatureValidation,
+  createHandler,
   ProviderService,
   PayoutRequest,
   PayoutResponse,
@@ -41,28 +39,40 @@ import {
 const networkPublicKey = process.env.NETWORK_PUBLIC_KEY!;
 
 const server = http.createServer(
-  signatureValidation(
-    nodeAdapter(
-      createService(networkPublicKey, (r) => {
-        r.service(ProviderService, {
-          async payOut(req: PayoutRequest, ctx: HandlerContext): Promise<PayoutResponse> {
-            // Handle payout requests from counterparts
-            return { result: { case: "accepted", value: {} } } as PayoutResponse;
-          },
-          async updatePayment(req: UpdatePaymentRequest, ctx: HandlerContext): Promise<UpdatePaymentResponse> {
-            // Handle payment status updates
-            return {} as UpdatePaymentResponse;
-          },
-        });
-      })
-    )
-  )
+  createHandler(networkPublicKey, (r) => {
+    r.service(ProviderService, {
+      async payOut(req: PayoutRequest, ctx: HandlerContext): Promise<PayoutResponse> {
+        // Handle payout requests from counterparts
+        return { result: { case: "accepted", value: {} } } as PayoutResponse;
+      },
+      async updatePayment(req: UpdatePaymentRequest, ctx: HandlerContext): Promise<UpdatePaymentResponse> {
+        // Handle payment status updates
+        return {} as UpdatePaymentResponse;
+      },
+    });
+  })
 );
 
 server.listen(3000);
 ```
 
-The middleware chain: `signatureValidation` captures raw request bytes for hashing, `nodeAdapter` bridges the RPC transport to Node.js HTTP, and `createService` registers your handlers with signature verification.
+`createHandler` composes the full middleware chain in one call: signature validation (raw byte capture), Connect-Node adapter, and service registration with signature verification.
+
+<details>
+<summary>Manual composition (advanced)</summary>
+
+For cases where you need to customize the middleware chain, the individual components are also exported:
+
+```ts
+import { createService, nodeAdapter, signatureValidation } from "@t-0/provider-sdk";
+
+const server = http.createServer(
+  signatureValidation(nodeAdapter(createService(networkPublicKey, registerRoutes)))
+);
+```
+
+`signatureValidation` captures raw request bytes for hashing, `nodeAdapter` bridges the RPC transport to Node.js HTTP, and `createService` registers your handlers with signature verification.
+</details>
 
 ### Standalone Signature Verification
 
@@ -70,7 +80,7 @@ For frameworks that don't use Node's `http.createServer` (Effect, Koa, Fastify, 
 
 ```ts
 import { fromBinary, toBinary } from "@bufbuild/protobuf";
-import { createRequestVerifier, PayoutRequestSchema, PayoutResponseSchema } from "@t-0/provider-sdk";
+import { createRequestVerifier, rejectRequest, PayoutRequestSchema, PayoutResponseSchema } from "@t-0/provider-sdk";
 
 const verify = createRequestVerifier({
   networkPublicKey: process.env.NETWORK_PUBLIC_KEY!,
@@ -86,10 +96,10 @@ function handleRequest(rawBody: Uint8Array, headers: Record<string, string>) {
   });
 
   if (!result.valid) {
-    // result.reason is one of: 'invalid_timestamp', 'timestamp_out_of_range',
-    // 'invalid_public_key', 'unknown_public_key', 'invalid_signature_format',
-    // 'signature_failed'
-    return errorResponse(result.reason);
+    // rejectRequest maps the failure reason to a well-formed HTTP error
+    // with status (400 or 401), Content-Type header, and JSON body.
+    const rejected = rejectRequest(result.reason);
+    return errorResponse(rejected.status, rejected.headers, rejected.body);
   }
 
   // Deserialize the Protobuf request (same raw bytes you verified)
@@ -110,7 +120,7 @@ The lower-level primitives are also exported individually: `verifySignature`, `c
 - **Raw body bytes only.** Pass the exact wire bytes to the verifier — no body parsers, no auto-decompression, never re-serialized protobuf. Protobuf encoding is not canonical; re-encoding produces different bytes and breaks verification.
 - **Pass `Uint8Array`, not `ArrayBuffer`.** If your framework gives you an `ArrayBuffer` (e.g. `request.arrayBuffer()`), wrap it: `new Uint8Array(buf)`.
 - **Header case.** `NetworkHeaders` enum values are title-case (`X-Signature`), but Node lowercases incoming headers. Look up headers by lowercase name: `headers["x-signature"]`.
-- **Wire format is binary protobuf.** Requests and successful responses use `Content-Type: application/proto`. Deserialize with `fromBinary()`, serialize with `toBinary()` from `@bufbuild/protobuf`. For errors, return a bare HTTP status code with no body (`401` for auth failures, `403` for permission errors). Success responses **must** include `Content-Type: application/proto`.
+- **Wire format is binary protobuf.** Requests and successful responses use `Content-Type: application/proto`. Deserialize with `fromBinary()`, serialize with `toBinary()` from `@bufbuild/protobuf`. For verification errors, use `rejectRequest(result.reason)` to get the correct HTTP status, headers, and JSON body. Success responses **must** include `Content-Type: application/proto`.
 - **Health endpoint.** The T-0 Network probes `/grpc.health.v1.Health/Check` on every endpoint. The probe is signed. Standalone integrations must route this path and return a valid health response. See [`docs/HEALTH_SERVICE.md`](../../docs/HEALTH_SERVICE.md) for the wire contract.
 - **`VerifyRequestFailure` is an open union.** New reason values may be added without a major version bump. Handle unknown reasons as generic failures.
 

--- a/node/sdk/src/common/crypto/index.ts
+++ b/node/sdk/src/common/crypto/index.ts
@@ -1,5 +1,5 @@
 export { verifySignature } from './verify.js'
 export { keccak256, computeDigest } from './hash.js'
 export { parsePublicKey, publicKeysEqual } from './keys.js'
-export { createRequestVerifier, DEFAULT_TOLERANCE_MS } from './request.js'
-export type { CreateVerifierOptions, VerifyRequest, VerifyRequestResult, VerifyRequestFailure, RequestVerifier } from './request.js'
+export { createRequestVerifier, DEFAULT_TOLERANCE_MS, rejectRequest } from './request.js'
+export type { CreateVerifierOptions, VerifyRequest, VerifyRequestResult, VerifyRequestFailure, RequestVerifier, RejectedRequest } from './request.js'

--- a/node/sdk/src/common/crypto/request.ts
+++ b/node/sdk/src/common/crypto/request.ts
@@ -82,3 +82,62 @@ export function createRequestVerifier(opts: CreateVerifierOptions): RequestVerif
     return { valid: true };
   };
 }
+
+export interface RejectedRequest {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export function rejectRequest(reason: VerifyRequestFailure): RejectedRequest {
+  let status: number;
+  let code: string;
+  let message: string;
+
+  switch (reason) {
+    case 'invalid_timestamp':
+      status = 400;
+      code = 'invalid_argument';
+      message = 'Invalid signature timestamp';
+      break;
+    case 'timestamp_out_of_range':
+      status = 400;
+      code = 'invalid_argument';
+      message = 'Signature timestamp out of range';
+      break;
+    case 'invalid_public_key':
+      status = 400;
+      code = 'invalid_argument';
+      message = 'Invalid public key format';
+      break;
+    case 'unknown_public_key':
+      status = 401;
+      code = 'unauthenticated';
+      message = 'Unknown public key';
+      break;
+    case 'invalid_signature_format':
+      status = 400;
+      code = 'invalid_argument';
+      message = 'Invalid signature format';
+      break;
+    case 'signature_failed':
+      status = 401;
+      code = 'unauthenticated';
+      message = 'Signature verification failed';
+      break;
+    default: {
+      const _exhaustive: never = reason;
+      void _exhaustive;
+      status = 401;
+      code = 'unauthenticated';
+      message = 'Request verification failed';
+      break;
+    }
+  }
+
+  return {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code, message }),
+  };
+}

--- a/node/sdk/src/common/node.ts
+++ b/node/sdk/src/common/node.ts
@@ -1,5 +1,7 @@
 import type * as http from "node:http";
 import {keccak_256} from "@noble/hashes/sha3.js";
+import { connectNodeAdapter } from "@connectrpc/connect-node";
+import { createService, type CreateServiceOptions, type Router } from "./service.js";
 
 export type NodeHandlerFn = (request: http.IncomingMessage, response: http.ServerResponse) => void;
 
@@ -15,3 +17,10 @@ export const signatureValidation= (next: NodeHandlerFn): NodeHandlerFn => (req :
 
   next(req, resp);
 }
+
+export const createHandler = (
+  networkPublicKey: string | Buffer,
+  registerRoutes: (router: Router) => void,
+  options?: CreateServiceOptions,
+): NodeHandlerFn =>
+  signatureValidation(connectNodeAdapter(createService(networkPublicKey, registerRoutes, options)));

--- a/node/sdk/src/common/service.ts
+++ b/node/sdk/src/common/service.ts
@@ -71,7 +71,7 @@ const createSignatureVerification: (networkPublicKey: Buffer) => Interceptor = (
   return await next(req);
 };
 
-interface Router {
+export interface Router {
   service: <T extends DescService, I extends ServiceImpl<T>>(
     service: T,
     implementation: I,

--- a/node/sdk/src/service/node.ts
+++ b/node/sdk/src/service/node.ts
@@ -1,1 +1,13 @@
-export * from "../common/node.js";
+import { createHandler as createHandlerCommon } from "../common/node.js";
+import type { Router, CreateServiceOptions } from "../common/service.js";
+import { SDK_VERSION } from "../version.js";
+
+export { signatureValidation } from "../common/node.js";
+export type { NodeHandlerFn } from "../common/node.js";
+
+export const createHandler = (
+  networkPublicKey: string | Buffer,
+  registerRoutes: (router: Router) => void,
+  options?: CreateServiceOptions,
+): ReturnType<typeof createHandlerCommon> =>
+  createHandlerCommon(networkPublicKey, registerRoutes, { ...options, version: options?.version ?? SDK_VERSION });

--- a/node/sdk/src/service/service.ts
+++ b/node/sdk/src/service/service.ts
@@ -1,18 +1,12 @@
-import { createService as createServiceCommon, type CreateServiceOptions } from "../common/service.js";
+import { createService as createServiceCommon, type CreateServiceOptions, type Router } from "../common/service.js";
 import { SDK_VERSION } from "../version.js";
 
-export type { CreateServiceOptions } from "../common/service.js";
+export type { CreateServiceOptions, Router } from "../common/service.js";
 export { REQUEST_VALIDITY_MILLIS } from "../common/service.js";
-
-interface Router {
-  service: <T extends import("@bufbuild/protobuf").DescService, I extends import("@connectrpc/connect").ServiceImpl<T>>(
-    service: T,
-    implementation: I,
-  ) => void;
-}
 
 export const createService = (
   networkPublicKey: string | Buffer,
   registerRoutes: (router: Router) => void,
   options?: CreateServiceOptions,
-) => createServiceCommon(networkPublicKey, registerRoutes, { ...options, version: options?.version ?? SDK_VERSION });
+): ReturnType<typeof createServiceCommon> =>
+  createServiceCommon(networkPublicKey, registerRoutes, { ...options, version: options?.version ?? SDK_VERSION });

--- a/node/sdk/test/handler.test.ts
+++ b/node/sdk/test/handler.test.ts
@@ -1,0 +1,88 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { randomBytes } from 'node:crypto';
+import type { AddressInfo } from 'node:net';
+import { createClient } from '../src/client/client.js';
+import { createHandler } from '../src/index.js';
+import { SDK_VERSION } from '../src/version.js';
+import { SDK_VERSION_HEADER } from '../src/service/health.js';
+import {
+  Health,
+  HealthCheckResponse_ServingStatus,
+} from '../src/service/health_pb.js';
+import {
+  ConnectError,
+  Code,
+  createClient as createConnectClient,
+} from '@connectrpc/connect';
+import { createConnectTransport } from '@connectrpc/connect-web';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+
+function newKeypair() {
+  const priv = Uint8Array.from(randomBytes(32));
+  const pub = secp256k1.getPublicKey(priv, false);
+  return {
+    privateKeyHex: '0x' + Buffer.from(priv).toString('hex'),
+    publicKeyHex: '0x' + Buffer.from(pub).toString('hex'),
+  };
+}
+
+async function bootServer(
+  networkPublicKeyHex: string,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const handler = createHandler(networkPublicKeyHex, () => {});
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe('createHandler', () => {
+  it('signed health check returns SERVING', async () => {
+    const { privateKeyHex, publicKeyHex } = newKeypair();
+    const { url, close } = await bootServer(publicKeyHex);
+    try {
+      const client = createClient(privateKeyHex, url, Health);
+      const resp = await client.check({ service: '' });
+      assert.equal(resp.status, HealthCheckResponse_ServingStatus.SERVING);
+    } finally {
+      await close();
+    }
+  });
+
+  it('stamps T0-Sdk-Version header equal to SDK_VERSION', async () => {
+    const { privateKeyHex, publicKeyHex } = newKeypair();
+    const { url, close } = await bootServer(publicKeyHex);
+    try {
+      const client = createClient(privateKeyHex, url, Health);
+      const headers = new Headers();
+      await client.check({ service: '' }, { onHeader: (h) => h.forEach((v, k) => headers.set(k, v)) });
+      assert.equal(headers.get(SDK_VERSION_HEADER.toLowerCase()), SDK_VERSION);
+    } finally {
+      await close();
+    }
+  });
+
+  it('unsigned request is rejected', async () => {
+    const { publicKeyHex } = newKeypair();
+    const { url, close } = await bootServer(publicKeyHex);
+    try {
+      const transport = createConnectTransport({ baseUrl: url, fetch: globalThis.fetch });
+      const client = createConnectClient(Health, transport);
+      await assert.rejects(
+        async () => client.check({ service: '' }),
+        (err: unknown) => {
+          assert.ok(err instanceof ConnectError);
+          assert.equal((err as ConnectError).code, Code.InvalidArgument);
+          return true;
+        },
+      );
+    } finally {
+      await close();
+    }
+  });
+});

--- a/node/sdk/test/reject.test.ts
+++ b/node/sdk/test/reject.test.ts
@@ -1,0 +1,121 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { randomBytes } from 'node:crypto';
+import type { AddressInfo } from 'node:net';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import {
+  rejectRequest,
+  createRequestVerifier,
+  computeDigest,
+  type VerifyRequestFailure,
+} from '../src/index.js';
+
+describe('rejectRequest', () => {
+  const badRequestReasons: VerifyRequestFailure[] = [
+    'invalid_timestamp',
+    'timestamp_out_of_range',
+    'invalid_public_key',
+    'invalid_signature_format',
+  ];
+
+  const unauthenticatedReasons: VerifyRequestFailure[] = [
+    'unknown_public_key',
+    'signature_failed',
+  ];
+
+  for (const reason of badRequestReasons) {
+    it(`maps "${reason}" to 400`, () => {
+      const result = rejectRequest(reason);
+      assert.equal(result.status, 400);
+      assert.equal(result.headers['Content-Type'], 'application/json');
+      const body = JSON.parse(result.body);
+      assert.equal(body.code, 'invalid_argument');
+      assert.ok(body.message.length > 0);
+    });
+  }
+
+  for (const reason of unauthenticatedReasons) {
+    it(`maps "${reason}" to 401`, () => {
+      const result = rejectRequest(reason);
+      assert.equal(result.status, 401);
+      assert.equal(result.headers['Content-Type'], 'application/json');
+      const body = JSON.parse(result.body);
+      assert.equal(body.code, 'unauthenticated');
+      assert.ok(body.message.length > 0);
+    });
+  }
+
+  it('round-trips with createRequestVerifier against a raw http server', async () => {
+    const priv = Uint8Array.from(randomBytes(32));
+    const pub = secp256k1.getPublicKey(priv, false);
+    const pubHex = '0x' + Buffer.from(pub).toString('hex');
+
+    const verify = createRequestVerifier({ networkPublicKey: pubHex });
+
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        const body = Buffer.concat(chunks);
+        const result = verify({
+          body,
+          signatureHeader: req.headers['x-signature'] as string,
+          publicKeyHeader: req.headers['x-public-key'] as string,
+          timestampHeader: req.headers['x-signature-timestamp'] as string,
+        });
+
+        if (!result.valid) {
+          const rejected = rejectRequest(result.reason);
+          res.writeHead(rejected.status, rejected.headers);
+          res.end(rejected.body);
+          return;
+        }
+
+        res.writeHead(200);
+        res.end('ok');
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    try {
+      // Valid signed request should pass
+      const payload = Buffer.from('hello');
+      const ts = Date.now();
+      const digest = computeDigest(payload, ts);
+      const sig = secp256k1.sign(digest, priv, { prehash: false });
+      const sigBytes = Buffer.from(sig).subarray(0, 64);
+      const sigHex = '0x' + sigBytes.toString('hex');
+
+      const okResp = await fetch(baseUrl, {
+        method: 'POST',
+        body: payload,
+        headers: {
+          'x-signature': sigHex,
+          'x-public-key': pubHex,
+          'x-signature-timestamp': String(ts),
+        },
+      });
+      assert.equal(okResp.status, 200);
+
+      // Invalid signature should get a mapped rejection
+      const badResp = await fetch(baseUrl, {
+        method: 'POST',
+        body: payload,
+        headers: {
+          'x-signature': '0x' + '00'.repeat(64),
+          'x-public-key': pubHex,
+          'x-signature-timestamp': String(ts),
+        },
+      });
+      assert.equal(badResp.status, 401);
+      const badBody = await badResp.json();
+      assert.equal(badBody.code, 'unauthenticated');
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #256.

- **`rejectRequest(reason)`** — maps a `VerifyRequestFailure` reason to a well-formed HTTP error response (`{status, headers, body}`) with Connect-style JSON. Status mapping matches the existing Connect interceptor: `invalid_timestamp`/`timestamp_out_of_range`/`invalid_public_key`/`invalid_signature_format` → 400, `unknown_public_key`/`signature_failed` → 401. Includes exhaustive switch with `never` guard + runtime fallback for future-proofing the open union.
- **`createHandler(networkPublicKey, registerRoutes, options?)`** — one-call composition of `signatureValidation(nodeAdapter(createService(...)))`, replacing the manual 3-step chain every consuming SDK re-implements. The `service/node.ts` wrapper injects `SDK_VERSION` (same pattern as `createService`).
- **`Router` type** — exported from `common/service.ts`, duplicate removed from `service/service.ts`.
- **`RejectedRequest` type** — return type of `rejectRequest`, exported via `crypto/index.ts`.
- README updated: `createHandler` is now the recommended API, `rejectRequest` replaces the `errorResponse(result.reason)` placeholder.

## Test plan

- [x] Unit tests for all 6 `VerifyRequestFailure` reasons: correct status (400/401), `Content-Type: application/json`, parseable JSON body with correct code
- [x] Round-trip test: raw `http.createServer` with `createRequestVerifier` + `rejectRequest` — valid signed request passes, invalid gets mapped rejection
- [x] `createHandler` boots server, signed health check returns SERVING
- [x] `T0-Sdk-Version` header equals `SDK_VERSION` (proves version injection)
- [x] Unsigned request rejected with InvalidArgument
- [x] ESM + CJS build passes, both surfaces verified (`typeof rejectRequest === 'function'`, `typeof createHandler === 'function'`)
- [x] All 145 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThfWqf6ZApXaUrg1nRYX7b