### PR TITLE
Add CLI sync workflow to usdt-pay-sdk

### DIFF
--- a/.github/workflows/cli-sync-config/usdt-pay-sdk.yaml
+++ b/.github/workflows/cli-sync-config/usdt-pay-sdk.yaml
@@ -1,0 +1,27 @@
+settings:
+  pull_request:
+    labels:
+      - "sync cli"
+    commit:
+      message: "Sync unified CLI from provider-sdk"
+
+patterns:
+  - files:
+      - from: cli/main.go
+        to: cli/main.go
+      - from: cli/scaffold.go
+        to: cli/scaffold.go
+      - from: cli/keygen.go
+        to: cli/keygen.go
+      - from: cli/keygen_test.go
+        to: cli/keygen_test.go
+      - from: cli/env.go
+        to: cli/env.go
+      - from: cli/go.mod
+        to: cli/go.mod
+      - from: cli/go.sum
+        to: cli/go.sum
+      - from: cli/internal/sync/main.go
+        to: cli/internal/sync/main.go
+    repositories:
+      - t-0-network/usdt-pay-sdk

--- a/.github/workflows/cli_sync.yaml
+++ b/.github/workflows/cli_sync.yaml
@@ -9,6 +9,8 @@ on:
       - "!cli/generate.go"
       - "!cli/install.sh"
       - "!cli/install.ps1"
+      - ".github/workflows/cli_sync.yaml"
+      - ".github/workflows/cli-sync-config/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cli_sync.yaml
+++ b/.github/workflows/cli_sync.yaml
@@ -1,0 +1,33 @@
+name: Sync CLI
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "cli/**"
+      - "!cli/config.go"
+      - "!cli/generate.go"
+      - "!cli/install.sh"
+      - "!cli/install.ps1"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          show-progress: false
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: usdt-pay-sdk
+
+      - uses: wadackel/files-sync-action@v3
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          config_file: .github/workflows/cli-sync-config/usdt-pay-sdk.yaml


### PR DESCRIPTION
## Summary

- Add `cli_sync.yaml` workflow triggered on `cli/` changes (push to master, workflow_dispatch)
- Add `cli-sync-config/usdt-pay-sdk.yaml` mapping 8 CLI source files
- Uses `wadackel/files-sync-action@v3` (same pattern as proto sync from backend)
- Creates PRs in usdt-pay-sdk with label `sync cli`

## Synced files (8)

`main.go`, `scaffold.go`, `keygen.go`, `keygen_test.go`, `env.go`, `go.mod`, `go.sum`, `internal/sync/main.go`

## Excluded (per-repo)

- `config.go` — product name, languages, role config
- `generate.go` — `//go:generate` args (which templates to sync)
- `install.sh` / `install.ps1` — hardcode repo name and binary name

## Related

- Companion PR in usdt-pay-sdk adds the per-repo config files
- Part of usdt-pay-sdk#50 (Unified CLI Phase 5)

## Test plan

- [ ] Verify sync config lists exactly 8 files
- [ ] Manually trigger `workflow_dispatch` after merge
- [ ] Confirm PR appears in usdt-pay-sdk with correct files
- [ ] Confirm per-repo files (`config.go`, `generate.go`) are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TepUEfU8Jo8Pi1vrx5mAhu