### PR TITLE
Fix CLI scaffolder: key injection, keygen, and PostScaffold hook

### DIFF
--- a/cli/env.go
+++ b/cli/env.go
@@ -20,14 +20,19 @@ func writeEnvFile(projectDir string, kp KeyPair) error {
 	content := string(data)
 
 	// Replace private key placeholder — templates use various patterns:
-	//   PROVIDER_PRIVATE_KEY=your_private_key_here  (Go, Python, Node)
-	//   PROVIDER_PRIVATE_KEY=                        (Java, C#)
+	//   PRIVATE_KEY=your_private_key_here
+	//   PRIVATE_KEY=
+	//   PROVIDER_PRIVATE_KEY=your_private_key_here  (provider-sdk default)
+	//   PROVIDER_PRIVATE_KEY=                        (provider-sdk default)
 	for _, pattern := range []string{
+		"PRIVATE_KEY=your_private_key_here",
+		"PRIVATE_KEY=",
 		"PROVIDER_PRIVATE_KEY=your_private_key_here",
 		"PROVIDER_PRIVATE_KEY=",
 	} {
 		if strings.Contains(content, pattern) {
-			content = strings.Replace(content, pattern, "PROVIDER_PRIVATE_KEY="+kp.PrivateKey, 1)
+			varName := pattern[:strings.Index(pattern, "=")]
+			content = strings.Replace(content, pattern, varName+"="+kp.PrivateKey, 1)
 			break
 		}
 	}

--- a/cli/main.go
+++ b/cli/main.go
@@ -116,6 +116,15 @@ func main() {
 			os.Exit(1)
 		}
 
+	case "keygen":
+		kp, err := generateKeyPair()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s %v\n", color(red, "[ERROR]"), err)
+			os.Exit(1)
+		}
+		fmt.Printf("Private key: %s\n", kp.PrivateKey)
+		fmt.Printf("Public key:  %s\n", kp.PublicKey)
+
 	case "--version", "-v", "version":
 		fmt.Printf("%s %s\n", Config.ProductName, Version)
 
@@ -154,6 +163,14 @@ func run(opts ScaffoldOpts) error {
 		return fmt.Errorf("scaffolding: %w", err)
 	}
 	fmt.Printf("%s Template files extracted\n", color(green, "[OK]"))
+
+	// Product-specific post-scaffold hook
+	if Config.PostScaffold != nil {
+		if err := Config.PostScaffold(opts); err != nil {
+			os.RemoveAll(opts.ProjectDir)
+			return fmt.Errorf("post-scaffold: %w", err)
+		}
+	}
 
 	// Generate keypair
 	fmt.Printf("%s Generating secp256k1 keypair...\n", color(blue, "[INFO]"))
@@ -227,13 +244,16 @@ func printCompletion(opts ScaffoldOpts, kp KeyPair) {
 }
 
 func printUsage() {
-	fmt.Printf("Usage: %s [options] <project-name>\n", Config.Command)
+	fmt.Printf("Usage: %s <command> [options]\n", Config.ProductName)
 	fmt.Println()
-	fmt.Println("Initialize a new T-0 Network provider project.")
+	fmt.Println("Commands:")
+	fmt.Printf("  init <project-name>  Initialize a new T-0 Network provider project\n")
+	fmt.Printf("  keygen               Generate a new secp256k1 keypair\n")
+	fmt.Printf("  version              Show version\n")
 	fmt.Println()
 	fmt.Printf("Languages: %s\n", strings.Join(Config.Languages, ", "))
 	fmt.Println()
-	fmt.Println("Options:")
+	fmt.Println("Init options:")
 	fmt.Println("  --lang string        Language/ecosystem (required)")
 	fmt.Println("  --module string      Go module path (Go only)")
 	fmt.Println("  --repository string  Java SDK repository: jitpack|maven-central (Java only)")

--- a/cli/scaffold.go
+++ b/cli/scaffold.go
@@ -20,6 +20,7 @@ type CLIConfig struct {
 	RoleRequired bool
 	DefaultRole  string
 	Languages    []string
+	PostScaffold func(ScaffoldOpts) error
 }
 
 type ScaffoldOpts struct {


### PR DESCRIPTION
## Summary

Three fixes for the unified CLI that were found during end-to-end validation in usdt-pay-sdk (t-0-network/usdt-pay-sdk#55):

- **Private key not injected into `.env`**: templates that use `PRIVATE_KEY=` (instead of `PROVIDER_PRIVATE_KEY=`) got no key written. Now tries both patterns and preserves the variable name.
- **`keygen` command missing from dispatch**: `keygen.go` defined `generateKeyPair()` but main.go didn't route the `keygen` subcommand. Now `./t0 keygen` works.
- **`PostScaffold` hook**: new optional `func(ScaffoldOpts) error` field on `CLIConfig`. Called after template extraction, before keypair generation. Lets downstream repos (usdt-pay-sdk) add product-specific steps like writing `gradle.properties`.

### Sync note

Once merged, the next CLI sync to usdt-pay-sdk will carry these changes. The corresponding usdt-pay-sdk PR (t-0-network/usdt-pay-sdk#55) has the same edits applied locally plus the product-specific `PostScaffold` implementation in `config.go`.

## Test plan

- [x] `go generate ./... && go build && go test ./...` passes
- [x] `./t0 keygen` generates valid secp256k1 keypair
- [x] `./t0 --help` shows updated usage with all commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KqtUsgZhv1n6PzimGwnMR