### PR TITLE
feat: SDK version override for Java, Go, Python, and C#

### DIFF
--- a/.github/workflows/ci-cli.yaml
+++ b/.github/workflows/ci-cli.yaml
@@ -128,7 +128,15 @@ jobs:
           PROXY_DIR="${RUNNER_TEMP}/goproxy"
           GOPROXY=direct go -C .github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "${VERSION}" "${PROXY_DIR}"
           cd test-go
-          GOPROXY="file://${PROXY_DIR},direct" GONOSUMDB="github.com/t-0-network" go build ./...
+          # In PRs the SDK source may differ from the published tag, producing a
+          # different module hash.  Drop the stale go.sum entries and re-tidy so
+          # Go fetches the locally-built archive without a checksum conflict.
+          sed -i '/^github.com\/t-0-network\/provider-sdk\/go /d' go.sum
+          export GOMODCACHE="${RUNNER_TEMP}/template-modcache"
+          export GOPROXY="file://${PROXY_DIR},direct"
+          export GONOSUMDB="github.com/t-0-network"
+          go mod tidy
+          go build ./...
 
       - name: Verify Node scaffold compiles
         working-directory: test-node

--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -61,4 +61,12 @@ jobs:
           PROXY_DIR="${RUNNER_TEMP}/goproxy"
           GOPROXY=direct go -C ../.github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "${VERSION}" "${PROXY_DIR}"
           cd starter/template
-          GOPROXY="file://${PROXY_DIR},direct" GONOSUMDB="github.com/t-0-network" go build ./...
+          # In PRs the SDK source may differ from the published tag, producing a
+          # different module hash.  Drop the stale go.sum entries and re-tidy so
+          # Go fetches the locally-built archive without a checksum conflict.
+          sed -i '/^github.com\/t-0-network\/provider-sdk\/go /d' go.sum
+          export GOMODCACHE="${RUNNER_TEMP}/template-modcache"
+          export GOPROXY="file://${PROXY_DIR},direct"
+          export GONOSUMDB="github.com/t-0-network"
+          go mod tidy
+          go build ./...

--- a/csharp/sdk/T0.ProviderSdk.Tests/Provider/HealthServiceImplTests.cs
+++ b/csharp/sdk/T0.ProviderSdk.Tests/Provider/HealthServiceImplTests.cs
@@ -145,6 +145,32 @@ public class HealthServiceImplTests
         }
     }
 
+    [Fact]
+    public async Task CheckResponse_CarriesOverriddenSdkVersion()
+    {
+        var (server, port) = NewServer();
+        server.WithSdkVersion("9.9.9-test");
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var serverTask = server.RunAsync(cts.Token);
+
+        try
+        {
+            await WaitForPortAsync(port, TimeSpan.FromSeconds(10));
+
+            using var call = NewSignedClient(port).CheckAsync(new HealthCheckRequest());
+            await call.ResponseAsync;
+            var headers = await call.ResponseHeadersAsync;
+
+            Assert.Equal("9.9.9-test", headers.GetValue(HealthServiceImpl.SdkVersionHeader));
+        }
+        finally
+        {
+            cts.Cancel();
+            try { await serverTask; }
+            catch (OperationCanceledException) { }
+        }
+    }
+
     /// <summary>
     /// The probe is signed like every other call the Network makes. Without this
     /// the transport would be publishing an unauthenticated endpoint on a

--- a/csharp/sdk/T0.ProviderSdk/Provider/HealthServiceImpl.cs
+++ b/csharp/sdk/T0.ProviderSdk/Provider/HealthServiceImpl.cs
@@ -35,10 +35,12 @@ internal sealed class HealthServiceImpl : Health.HealthBase
     private static readonly string CachedSdkVersion = LoadSdkVersion();
 
     private readonly HashSet<string> _registered;
+    private readonly string? _versionOverride;
 
-    public HealthServiceImpl(IEnumerable<string> services)
+    public HealthServiceImpl(IEnumerable<string> services, string? versionOverride = null)
     {
         _registered = new HashSet<string>(services);
+        _versionOverride = versionOverride;
     }
 
     public override async Task<HealthCheckResponse> Check(HealthCheckRequest request, ServerCallContext context)
@@ -46,7 +48,7 @@ internal sealed class HealthServiceImpl : Health.HealthBase
         await context.WriteResponseHeadersAsync(new Metadata
         {
             { SdkEcosystemHeader, SdkEcosystem },
-            { SdkVersionHeader, CachedSdkVersion },
+            { SdkVersionHeader, _versionOverride ?? CachedSdkVersion },
         });
 
         // An empty service name asks about the process as a whole, which is up if

--- a/csharp/sdk/T0.ProviderSdk/T0ProviderServer.cs
+++ b/csharp/sdk/T0.ProviderSdk/T0ProviderServer.cs
@@ -21,6 +21,7 @@ public sealed class T0ProviderServer
     private readonly T0Config _config;
     private readonly List<Action<WebApplication>> _mapActions = [];
     private readonly List<string> _registeredFqns = [];
+    private string? _sdkVersion;
 
     public T0ProviderServer(T0Config config, Signer signer, string[]? args = null)
     {
@@ -74,6 +75,18 @@ public sealed class T0ProviderServer
     }
 
     /// <summary>
+    /// Overrides the SDK version reported in health-check response headers.
+    /// Wrapping SDKs use this to stamp their own version instead of the
+    /// provider-sdk's built-in version.
+    /// </summary>
+    public T0ProviderServer WithSdkVersion(string version)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        _sdkVersion = version;
+        return this;
+    }
+
+    /// <summary>
     /// Builds and runs the provider server. Blocks until <paramref name="cancellationToken"/>
     /// fires or the host shuts down.
     /// </summary>
@@ -87,7 +100,7 @@ public sealed class T0ProviderServer
         {
             Health.Descriptor.FullName,
         };
-        _builder.Services.AddSingleton(new HealthServiceImpl(fqns));
+        _builder.Services.AddSingleton(new HealthServiceImpl(fqns, _sdkVersion));
 
         var app = _builder.Build();
 

--- a/go/provider/handler.go
+++ b/go/provider/handler.go
@@ -8,6 +8,8 @@ import (
 	"connectrpc.com/connect"
 
 	"connectrpc.com/grpchealth"
+
+	"github.com/t-0-network/provider-sdk/go/sdkversion"
 )
 
 type BuildHandler func(defaultOptions providerHandlerOptions) (path string, handler http.Handler)
@@ -26,6 +28,17 @@ func WithLogger(logger *slog.Logger) HttpHandlerOption {
 	return func(o *providerHandlerOptions) {
 		if logger != nil {
 			o.logger = logger
+		}
+	}
+}
+
+// WithSDKVersion overrides the SDK version reported in health-check response
+// headers. Wrapping SDKs use this to stamp their own version instead of the
+// provider-sdk's built-in version.
+func WithSDKVersion(version string) HttpHandlerOption {
+	return func(o *providerHandlerOptions) {
+		if strings.TrimSpace(version) != "" {
+			o.sdkVersion = version
 		}
 	}
 }
@@ -85,6 +98,11 @@ func NewHttpHandlerWithOptions(
 		return nil, err
 	}
 
+	sdkVer := scratch.sdkVersion
+	if sdkVer == "" {
+		sdkVer = sdkversion.Version
+	}
+
 	mux := http.NewServeMux()
 	registered := make([]string, 0, len(buildHandlers)+1)
 	for _, b := range buildHandlers {
@@ -104,7 +122,7 @@ func NewHttpHandlerWithOptions(
 		grpchealth.NewHandler,
 		grpchealth.Checker(newHealthChecker(registered)),
 		func(o *providerHandlerOptions) {
-			o.connectHandlerOptions = append(o.connectHandlerOptions, withSDKIdentity())
+			o.connectHandlerOptions = append(o.connectHandlerOptions, withSDKIdentity(sdkVer))
 		},
 	)
 	healthPath, healthHandler := healthBuild(defaultOptions)

--- a/go/provider/handler_option.go
+++ b/go/provider/handler_option.go
@@ -15,6 +15,7 @@ type providerHandlerOptions struct {
 	verifySignatureMaxBodySize int64
 	connectHandlerOptions      []connect.HandlerOption
 	logger                     *slog.Logger
+	sdkVersion                 string
 }
 
 func newDefaultHandlerOptions(verifySignatureFn VerifySignature, logger *slog.Logger) (providerHandlerOptions, error) {

--- a/go/provider/health.go
+++ b/go/provider/health.go
@@ -5,8 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"connectrpc.com/grpchealth"
-
-	"github.com/t-0-network/provider-sdk/go/sdkversion"
 )
 
 // Header names carrying the identity of the SDK answering the probe. They ride
@@ -53,7 +51,7 @@ func (h *healthChecker) Check(_ context.Context, req *grpchealth.CheckRequest) (
 }
 
 // withSDKIdentity stamps the SDK identity onto health responses.
-func withSDKIdentity() connect.HandlerOption {
+func withSDKIdentity(version string) connect.HandlerOption {
 	return connect.WithInterceptors(connect.UnaryInterceptorFunc(
 		func(next connect.UnaryFunc) connect.UnaryFunc {
 			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
@@ -62,7 +60,7 @@ func withSDKIdentity() connect.HandlerOption {
 					return nil, err
 				}
 				resp.Header().Set(SDKEcosystemHeader, sdkEcosystem)
-				resp.Header().Set(SDKVersionHeader, sdkversion.Version)
+				resp.Header().Set(SDKVersionHeader, version)
 				return resp, nil
 			}
 		},

--- a/go/provider/health_test.go
+++ b/go/provider/health_test.go
@@ -88,6 +88,43 @@ func TestHealth_ReportsSdkIdentityInResponseHeaders(t *testing.T) {
 	require.Equal(t, sdkversion.Version, resp.Header.Get(SDKVersionHeader))
 }
 
+func newHealthServerWithOptions(t *testing.T, opts ...HttpHandlerOption) (*httptest.Server, *secp256k1.PrivateKey) {
+	t.Helper()
+	priv, err := secp256k1.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	mux, err := NewHttpHandlerWithOptions(
+		NetworkPublicKeyHexed(crypto.HexPublicKey(priv.PubKey())),
+		opts,
+		Handler(paymentconnect.NewProviderServiceHandler, paymentconnect.ProviderServiceHandler(paymentconnect.UnimplementedProviderServiceHandler{})),
+	)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, priv
+}
+
+func TestHealth_ReportsOverriddenSdkVersionInResponseHeaders(t *testing.T) {
+	srv, priv := newHealthServerWithOptions(t, WithSDKVersion("9.9.9-test"))
+
+	signFn, err := crypto.NewSignerFromHex(crypto.HexPrivateKey(priv))
+	require.NoError(t, err)
+	signing := &http.Client{Transport: network.NewSigningTransport(signFn, time.Now)}
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/grpc.health.v1.Health/Check", strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := signing.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Equal(t, sdkEcosystem, resp.Header.Get(SDKEcosystemHeader))
+	require.Equal(t, "9.9.9-test", resp.Header.Get(SDKVersionHeader))
+}
+
 // The probe is signed like every other call the Network makes. Without this the
 // transport would be publishing an unauthenticated endpoint on a partner's port.
 func TestHealth_RejectsUnsignedRequest(t *testing.T) {

--- a/java/sdk/src/main/java/network/t0/sdk/provider/HealthServiceImpl.java
+++ b/java/sdk/src/main/java/network/t0/sdk/provider/HealthServiceImpl.java
@@ -66,7 +66,8 @@ final class HealthServiceImpl extends HealthGrpc.HealthImplBase {
     }
 
     /** Stamps the SDK identity onto responses from this service only. */
-    static ServerInterceptor sdkIdentityInterceptor() {
+    static ServerInterceptor sdkIdentityInterceptor(String versionOverride) {
+        String effectiveVersion = versionOverride != null ? versionOverride : SDK_VERSION;
         return new ServerInterceptor() {
             @Override
             public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
@@ -75,7 +76,7 @@ final class HealthServiceImpl extends HealthGrpc.HealthImplBase {
                     @Override
                     public void sendHeaders(Metadata responseHeaders) {
                         responseHeaders.put(SDK_ECOSYSTEM_HEADER, SDK_ECOSYSTEM);
-                        responseHeaders.put(SDK_VERSION_HEADER, SDK_VERSION);
+                        responseHeaders.put(SDK_VERSION_HEADER, effectiveVersion);
                         super.sendHeaders(responseHeaders);
                     }
                 }, headers);

--- a/java/sdk/src/main/java/network/t0/sdk/provider/ProviderServer.java
+++ b/java/sdk/src/main/java/network/t0/sdk/provider/ProviderServer.java
@@ -176,6 +176,7 @@ public final class ProviderServer implements Closeable {
         private int maxInboundMetadataSize = 8192; // 8KB default
         private long handshakeTimeout = 120;
         private TimeUnit handshakeTimeoutUnit = TimeUnit.SECONDS;
+        private String sdkVersion;
         private Logger sdkLogger = LoggerFactory.getLogger(ResponseValidationInterceptor.class);
 
         private Builder(int port, String networkPublicKey) {
@@ -253,6 +254,24 @@ public final class ProviderServer implements Closeable {
                 throw new IllegalArgumentException("logger must not be null");
             }
             this.sdkLogger = logger;
+            return this;
+        }
+
+        /**
+         * Overrides the SDK version reported in health-check response headers.
+         *
+         * <p>When set, the {@code t0-sdk-version} header carries this value instead
+         * of the version baked into the SDK jar.
+         *
+         * @param version the version string to report; must not be null or blank
+         * @return this builder
+         * @throws IllegalArgumentException if version is null or blank
+         */
+        public Builder withSdkVersion(String version) {
+            if (version == null || version.isBlank()) {
+                throw new IllegalArgumentException("version must not be null or blank");
+            }
+            this.sdkVersion = version;
             return this;
         }
 
@@ -339,7 +358,7 @@ public final class ProviderServer implements Closeable {
             BindableService healthSvc = new HealthServiceImpl(new HashSet<>(registeredFqns));
             ServerServiceDefinition healthDef = ServerInterceptors.useInputStreamMessages(healthSvc.bindService());
             builder.addService(ServerInterceptors.intercept(healthDef,
-                    HealthServiceImpl.sdkIdentityInterceptor(), verificationInterceptor, validationInterceptor));
+                    HealthServiceImpl.sdkIdentityInterceptor(sdkVersion), verificationInterceptor, validationInterceptor));
 
             return builder.build();
         }

--- a/java/sdk/src/test/java/network/t0/sdk/integration/HealthServiceIntegrationTest.java
+++ b/java/sdk/src/test/java/network/t0/sdk/integration/HealthServiceIntegrationTest.java
@@ -130,6 +130,31 @@ class HealthServiceIntegrationTest {
         assertThat(headers.get(SDK_VERSION_HEADER)).isEqualTo(loadExpectedSdkVersion());
     }
 
+    @Test
+    @DisplayName("Check response carries an overridden SDK version when withSdkVersion is used")
+    void checkResponse_carriesOverriddenSdkVersion() throws Exception {
+        try (ProviderServer overrideServer = ProviderServer.create(0, NETWORK_PUBLIC_KEY_HEX)
+                .withSdkVersion("9.9.9-test")
+                .withService(new TestProviderServiceImpl())
+                .start()) {
+
+            AtomicReference<Metadata> captured = new AtomicReference<>();
+
+            try (var client = BlockingNetworkClient.create(
+                    "http://localhost:" + overrideServer.getPort(),
+                    Signer.fromHex(NETWORK_PRIVATE_KEY),
+                    channel -> HealthGrpc.newBlockingStub(
+                            ClientInterceptors.intercept(channel, capturingInterceptor(captured))))) {
+
+                client.stub().check(HealthCheckRequest.getDefaultInstance());
+            }
+
+            Metadata headers = captured.get();
+            assertThat(headers).isNotNull();
+            assertThat(headers.get(SDK_VERSION_HEADER)).isEqualTo("9.9.9-test");
+        }
+    }
+
     /**
      * The probe is signed like every other call the Network makes. Without this the
      * transport would be publishing an unauthenticated endpoint on a partner's port.

--- a/python/sdk/src/t0_provider_sdk/provider/handler.py
+++ b/python/sdk/src/t0_provider_sdk/provider/handler.py
@@ -93,6 +93,7 @@ def new_asgi_app(
     network_public_key: str,
     *build_handlers: BuildHandler,
     logger: logging.Logger | None = None,
+    version: str | None = None,
 ) -> ASGIApp:
     """Create a composite ASGI app with signature verification.
 
@@ -105,6 +106,9 @@ def new_asgi_app(
         logger: Optional logger used by the response-validation interceptor when
             it catches an invalid response. Defaults to
             ``logging.getLogger("t0_provider_sdk")``.
+        version: Optional SDK version override. Wrapping SDKs pass their own
+            version so health probes report it instead of provider-sdk's
+            built-in version. Defaults to ``None`` (use built-in version).
 
     Returns:
         An ASGI application with signature verification middleware.
@@ -125,7 +129,7 @@ def new_asgi_app(
     service_names = [path.lstrip("/") for path in routes]
     service_names.append(HEALTH_SERVICE_FQN)
     health_app = HealthASGIApplication(
-        HealthImpl(service_names),
+        HealthImpl(service_names, version=version),
         interceptors=list(default_options.interceptors),
     )
     routes[health_app.path] = health_app
@@ -178,6 +182,7 @@ def new_wsgi_app(
     network_public_key: str,
     *build_handlers: BuildHandlerSync,
     logger: logging.Logger | None = None,
+    version: str | None = None,
 ) -> WSGIApp:
     """Create a composite WSGI app with signature verification.
 
@@ -190,6 +195,9 @@ def new_wsgi_app(
         logger: Optional logger used by the response-validation interceptor when
             it catches an invalid response. Defaults to
             ``logging.getLogger("t0_provider_sdk")``.
+        version: Optional SDK version override. Wrapping SDKs pass their own
+            version so health probes report it instead of provider-sdk's
+            built-in version. Defaults to ``None`` (use built-in version).
 
     Returns:
         A WSGI application with signature verification middleware.
@@ -210,7 +218,7 @@ def new_wsgi_app(
     service_names = [path.lstrip("/") for path in routes]
     service_names.append(HEALTH_SERVICE_FQN)
     health_app = HealthWSGIApplication(
-        HealthImplSync(service_names),
+        HealthImplSync(service_names, version=version),
         interceptors=list(default_options.interceptors),
     )
     routes[health_app.path] = health_app

--- a/python/sdk/src/t0_provider_sdk/provider/health.py
+++ b/python/sdk/src/t0_provider_sdk/provider/health.py
@@ -53,8 +53,9 @@ _CHECK_METHOD = MethodInfo(
 
 
 class _Health:
-    def __init__(self, services: Iterable[str]) -> None:
+    def __init__(self, services: Iterable[str], version: str | None = None) -> None:
         self._registered = frozenset(services)
+        self._version = version
 
     def _check(
         self,
@@ -62,7 +63,7 @@ class _Health:
         ctx: RequestContext,
     ) -> health_pb2.HealthCheckResponse:
         ctx.response_headers()[SDK_ECOSYSTEM_HEADER] = _SDK_ECOSYSTEM
-        ctx.response_headers()[SDK_VERSION_HEADER] = __version__
+        ctx.response_headers()[SDK_VERSION_HEADER] = self._version or __version__
 
         # An empty service name asks about the process as a whole, which is up if
         # this handler is running at all.

--- a/python/sdk/tests/integration/test_health_signed.py
+++ b/python/sdk/tests/integration/test_health_signed.py
@@ -169,3 +169,14 @@ def test_identity_headers_are_set_on_check():
 
     assert ctx.response_headers()[SDK_ECOSYSTEM_HEADER] == "python"
     assert ctx.response_headers()[SDK_VERSION_HEADER] == __version__
+
+
+def test_identity_headers_use_override_version():
+    """When a version override is provided, the health response carries it
+    instead of the SDK's built-in version."""
+    impl = HealthImplSync([PROVIDER_SERVICE_FQN], version="9.9.9-test")
+    ctx = RequestContext(method=_CHECK_METHOD, http_method="POST", request_headers=Headers())
+    impl.check(health_pb2.HealthCheckRequest(), ctx)
+
+    assert ctx.response_headers()[SDK_ECOSYSTEM_HEADER] == "python"
+    assert ctx.response_headers()[SDK_VERSION_HEADER] == "9.9.9-test"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -586,12 +586,12 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.2.0" },
-    { name = "protoc-gen-connectrpc", specifier = ">=0.11.0" },
+    { name = "mypy", specifier = ">=2.3.1" },
+    { name = "protoc-gen-connectrpc", specifier = ">=0.11.1" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
-    { name = "ruff", specifier = ">=0.15.20" },
-    { name = "uvicorn", specifier = ">=0.50.2" },
+    { name = "ruff", specifier = ">=0.16.4" },
+    { name = "uvicorn", specifier = ">=0.52.4" },
 ]
 
 [[package]]
@@ -789,7 +789,7 @@ wheels = [
 
 [[package]]
 name = "t0-provider-sdk"
-version = "1.1.28"
+version = "1.1.32"
 source = { editable = "sdk" }
 dependencies = [
     { name = "coincurve" },
@@ -825,7 +825,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "t0-provider-starter"
-version = "1.1.28"
+version = "1.1.32"
 source = { editable = "starter" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Add SDK version override to Java, Go, Python, and C# — matching the Node pattern shipped in v1.1.32
- Wrapping SDKs (like usdt-pay-sdk) can now pass their own version so health probes report the wrapper's version instead of provider-sdk's built-in version
- When unset, each platform falls back to the built-in SDK version — no breaking changes

### Per-platform API

| Platform | Public API | Fallback |
|----------|-----------|----------|
| Java | `Builder.withSdkVersion(String)` | `SDK_VERSION` from classpath resource |
| Go | `WithSDKVersion(string)` option | `sdkversion.Version` |
| Python | `version` kwarg on `new_asgi_app` / `new_wsgi_app` | `__version__` |
| C# | `T0ProviderServer.WithSdkVersion(string)` | `CachedSdkVersion` from assembly |

### No breaking changes

- Java: package-private `sdkIdentityInterceptor` signature change, new public builder method
- Go: unexported `withSDKIdentity` signature change, new public `HttpHandlerOption`
- Python: keyword-only `version=None` on existing functions
- C#: `internal` constructor gets optional parameter, new public fluent method

### Validation

- Empty/whitespace strings: Java and C# reject at entry; Go silently ignores; Python falls back via `or`
- All four test suites pass with new override tests asserting `"9.9.9-test"` in response headers

## Test plan

- [x] `cd java && ./gradlew build` — BUILD SUCCESSFUL
- [x] `cd go && go test ./...` — all pass
- [x] `cd python && uv run pytest -v` — 113 passed
- [x] `cd csharp/sdk && dotnet test` — 60 passed
- [x] Existing default-version tests unchanged and green
- [x] New override tests pass on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDTuV7ZTELxyHZiXp1uaX8