### PR TITLE
fix(node): two-sided timestamp validation in Connect interceptor

### DIFF
--- a/node/sdk/src/common/service.ts
+++ b/node/sdk/src/common/service.ts
@@ -45,7 +45,7 @@ export const REQUEST_VALIDITY_MILLIS = 60_000;
 
 const createSignatureVerification: (networkPublicKey: Buffer) => Interceptor = (networkPublicKey: Buffer) => (next) => async (req) => {
   const ts = decodeNum(getHeader(req, NetworkHeaders.SignatureTimestamp));
-  if (Date.now() - ts > 60_000) {
+  if (!Number.isFinite(ts) || Math.abs(Date.now() - ts) > REQUEST_VALIDITY_MILLIS) {
     throw new ConnectError(`${NetworkHeaders.SignatureTimestamp} must be within ${REQUEST_VALIDITY_MILLIS} milliseconds from now` , Code.InvalidArgument);
   }
 


### PR DESCRIPTION
## Summary

- **Two-sided timestamp check**: the Connect interceptor (`createSignatureVerification`) only rejected past timestamps (`Date.now() - ts > 60_000`), accepting timestamps arbitrarily far in the future. Now uses `Math.abs` for ±60s validation, matching the protocol spec and all other SDKs (Go, Java, C#, Python).
- **NaN guard**: `parseInt("abc")` → `NaN` passed the old check, then `BigInt(NaN)` on line 62 threw an unhandled `TypeError` (500). Now `Number.isFinite(ts)` rejects malformed headers with a clean `InvalidArgument` error.
- **Uses existing constant**: replaces the hardcoded `60_000` with the already-exported `REQUEST_VALIDITY_MILLIS`.

One-line change aligning the Connect interceptor to the already-correct `createRequestVerifier` in the same package.

Closes #206, #249

## Test plan

- [x] `npm run build` — type-checks clean (ESM + CJS)
- [x] `npm test` — all 145 tests pass
- [ ] Verify `NaN` path: `!Number.isFinite(NaN)` → `true` → rejected
- [ ] Verify future timestamp: `Math.abs(Date.now() - (Date.now() + 120000))` → `120000 > 60000` → rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKyStMepiRRFoMriQt4th7