### PR TITLE
feat(network): add WithTransport option to SigningTransport

### DIFF
--- a/go/network/signing_transport.go
+++ b/go/network/signing_transport.go
@@ -14,12 +14,25 @@ import (
 	"github.com/t-0-network/provider-sdk/go/crypto"
 )
 
-func NewSigningTransport(signFn crypto.SignFn, timeNow func() time.Time) *SigningTransport {
-	return &SigningTransport{
+// SigningTransportOption configures a SigningTransport.
+type SigningTransportOption func(*SigningTransport)
+
+// WithTransport overrides the underlying RoundTripper.
+// Default: http.DefaultTransport.
+func WithTransport(rt http.RoundTripper) SigningTransportOption {
+	return func(st *SigningTransport) { st.transport = rt }
+}
+
+func NewSigningTransport(signFn crypto.SignFn, timeNow func() time.Time, opts ...SigningTransportOption) *SigningTransport {
+	st := &SigningTransport{
 		transport: http.DefaultTransport,
 		sign:      signFn,
 		timeNow:   timeNow,
 	}
+	for _, o := range opts {
+		o(st)
+	}
+	return st
 }
 
 // SigningTransport is an HTTP transport that signs requests with a given signing function.


### PR DESCRIPTION
## Summary
- Adds `SigningTransportOption` type and `WithTransport` function to allow overriding the underlying `http.RoundTripper` in `SigningTransport`
- Enables tests to inject an in-memory transport for `httptest.NewTestServer`, eliminating TCP listeners from integration tests
- Backward-compatible: existing callers without options continue to use `http.DefaultTransport`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests unaffected — variadic opts are backward-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)