### PR TITLE
fix(node): export createRequestDecoder from main entry

### DIFF
--- a/node/sdk/src/index.ts
+++ b/node/sdk/src/index.ts
@@ -1,4 +1,4 @@
-export { verifySignature, keccak256, computeDigest, parsePublicKey, publicKeysEqual, createRequestVerifier, DEFAULT_TOLERANCE_MS, rejectRequest } from "./crypto/index.js"
+export { verifySignature, keccak256, computeDigest, parsePublicKey, publicKeysEqual, createRequestVerifier, createRequestDecoder, DEFAULT_TOLERANCE_MS, rejectRequest } from "./crypto/index.js"
 export type { CreateVerifierOptions, VerifyRequest, VerifyRequestResult, VerifyRequestFailure, RequestVerifier, RejectedRequest, CreateDecoderOptions, IncomingHeaders, IncomingRequest, WireFormat, DecodeRequestFailure, Violation, WireResponse, DecodeError, DecodeRequestResult, RequestDecoder } from "./crypto/index.js"
 export * from "./client/client.js"
 export * from "./service/service.js"


### PR DESCRIPTION
## Summary

- Re-export `createRequestDecoder` from the main package entry (`src/index.ts`), alongside `createRequestVerifier` and the other crypto factories
- The decoder types (`RequestDecoder`, `DecodeRequestResult`, etc.) were already on the main entry — only the function itself was missing, forcing consumers to import from the `/crypto` subpath
- This lets `usdt-pay-sdk` import it the same way as every other factory — no `tsconfig.cjs.json` changes needed to work around `node10` not resolving subpath exports

## Test plan

- [x] `npm run build` passes (ESM + CJS)
- [x] `npm test` — 164 tests pass, no regressions
- [x] `createRequestDecoder` present in both `lib/esm/index.d.ts` and `lib/cjs/index.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018a5RJa89adW1zkXdi5RoBb