### PR TITLE
ci: run unlocked latest-deps jobs daily for Python and Node, open an issue on failure

### DIFF
--- a/.github/workflows/ci-node.yaml
+++ b/.github/workflows/ci-node.yaml
@@ -1,6 +1,11 @@
 name: CI / Node
 
 on:
+  # Customers resolve our caret ranges to the newest release within each
+  # major, on npm's schedule, not ours. Run the unlocked job daily.
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
   push:
     branches: [master]
     paths:
@@ -23,6 +28,9 @@ concurrency:
 jobs:
   node:
     name: Node
+    # The lockfile does not change between commits; only the unlocked job is
+    # worth re-running on the timer.
+    if: github.event_name != 'schedule'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -67,3 +75,66 @@ jobs:
       - name: Type-check starter template against local SDK
         working-directory: node/starter/template
         run: npx tsc --noEmit -p tsconfig.json
+
+  # The job above tests package-lock.json. Customers never see that file: npm
+  # resolves the SDK's caret ranges to the newest release within each major at
+  # install time. This job drops the lockfile, installs whatever npm serves
+  # today, and runs the suite on that, so an upstream release that breaks the
+  # SDK shows up here before a customer reports it.
+  node-latest-deps:
+    name: Node (unlocked latest deps)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          show-progress: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+
+      - name: Install SDK dependencies without the lockfile
+        working-directory: node/sdk
+        run: |
+          rm -f package-lock.json
+          npm install --no-audit --no-fund
+
+      - name: Show resolved versions
+        working-directory: node/sdk
+        run: npm ls --depth=0
+
+      - name: Build SDK
+        working-directory: node/sdk
+        run: npm run build
+
+      - name: Run SDK tests against latest dependencies
+        working-directory: node/sdk
+        run: npm test
+
+      # A red scheduled run only emails whoever last edited this file. Open an
+      # issue instead (one at a time) so the break is visible to the team.
+      - name: Open issue on scheduled failure
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create latest-deps --force \
+            --description "SDK broke against the newest published dependencies" \
+            --color D93F0B
+          open_count=$(gh issue list --label latest-deps --search "Node SDK" --state open --json number --jq 'length')
+          if [ "$open_count" = "0" ]; then
+            gh issue create --label latest-deps \
+              --title "Node SDK fails against latest npm dependencies" \
+              --body "The scheduled unlocked-dependencies run failed: $RUN_URL
+
+          The \"Show resolved versions\" step in that run lists what npm served. Compare it with node/sdk/package-lock.json to find the release that broke the SDK, then follow .claude/skills/dependency-update/SKILL.md."
+          else
+            gh issue comment "$(gh issue list --label latest-deps --search "Node SDK" --state open --json number --jq '.[0].number')" \
+              --body "Still failing: $RUN_URL"
+          fi

--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -1,6 +1,11 @@
 name: CI / Python
 
 on:
+  # Upstream breaks on PyPI's schedule, not ours: run the unlocked job daily so
+  # a breaking release is caught the next morning instead of by a customer.
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
   push:
     branches: [master]
     paths:
@@ -23,6 +28,9 @@ concurrency:
 jobs:
   python:
     name: Python
+    # The lockfile does not change between commits; only the unlocked job is
+    # worth re-running on the timer.
+    if: github.event_name != 'schedule'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -76,6 +84,9 @@ jobs:
   python-latest-deps:
     name: Python (unlocked latest deps)
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -108,3 +119,26 @@ jobs:
       - name: Run SDK tests against latest dependencies
         working-directory: python/sdk
         run: ../.venv-latest/bin/python -m pytest tests -p no:cacheprovider
+
+      # A red scheduled run only emails whoever last edited this file. Open an
+      # issue instead (one at a time) so the break is visible to the team.
+      - name: Open issue on scheduled failure
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create latest-deps --force \
+            --description "Python SDK broke against the newest PyPI dependencies" \
+            --color D93F0B
+          open_count=$(gh issue list --label latest-deps --state open --json number --jq 'length')
+          if [ "$open_count" = "0" ]; then
+            gh issue create --label latest-deps \
+              --title "Python SDK fails against latest PyPI dependencies" \
+              --body "The scheduled unlocked-dependencies run failed: $RUN_URL
+
+          The \"Show resolved versions\" step in that run lists what PyPI served. Compare it with python/uv.lock to find the release that broke the SDK, then follow .claude/skills/dependency-update/SKILL.md."
+          else
+            gh issue comment "$(gh issue list --label latest-deps --state open --json number --jq '.[0].number')" \
+              --body "Still failing: $RUN_URL"
+          fi

--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -129,9 +129,9 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh label create latest-deps --force \
-            --description "Python SDK broke against the newest PyPI dependencies" \
+            --description "SDK broke against the newest published dependencies" \
             --color D93F0B
-          open_count=$(gh issue list --label latest-deps --state open --json number --jq 'length')
+          open_count=$(gh issue list --label latest-deps --search "Python SDK" --state open --json number --jq 'length')
           if [ "$open_count" = "0" ]; then
             gh issue create --label latest-deps \
               --title "Python SDK fails against latest PyPI dependencies" \
@@ -139,6 +139,6 @@ jobs:
 
           The \"Show resolved versions\" step in that run lists what PyPI served. Compare it with python/uv.lock to find the release that broke the SDK, then follow .claude/skills/dependency-update/SKILL.md."
           else
-            gh issue comment "$(gh issue list --label latest-deps --state open --json number --jq '.[0].number')" \
+            gh issue comment "$(gh issue list --label latest-deps --search "Python SDK" --state open --json number --jq '.[0].number')" \
               --body "Still failing: $RUN_URL"
           fi


### PR DESCRIPTION
## Summary

Stacked on #298. That PR adds a `python-latest-deps` job that installs the SDK wheel with the newest resolvable dependencies, the way customers do. It only ran on pushes and PRs though, and upstream breaks land on PyPI's schedule, not ours. This makes it a daily canary with a visible alert.

## Changes

- `schedule: "0 6 * * *"` and `workflow_dispatch` triggers on `ci-python.yaml`.
- The lockfile job is skipped on scheduled runs (`if: github.event_name != 'schedule'`) since nothing in the repo changed.
- `python-latest-deps` gets `issues: write` and a final step that runs only on a scheduled or manual failure: it ensures a `latest-deps` label exists, opens an issue linking to the run if none is open, and otherwise comments "still failing" on the existing one.

### Node

Node is the only other ecosystem where a customer's install floats: npm resolves the SDK's caret ranges to the newest release within each major, while CI only tested `package-lock.json`. Go (minimum version selection), Java (fixed POM versions), and C# (NuGet lowest-applicable) hand consumers the declared versions, so they need no equivalent.

- `ci-node.yaml` gets the same `schedule` and `workflow_dispatch` triggers, the lockfile job is skipped on the timer, and a new `node-latest-deps` job deletes `package-lock.json`, runs `npm install`, prints `npm ls --depth=0`, builds, and runs the suite, with the same issue-on-failure step.
- Both jobs' issue lookup is scoped by title (`Python SDK` / `Node SDK`) so they track separate issues under the shared `latest-deps` label.
- Rehearsed locally: resolves connect 2.1.2, `@bufbuild/protobuf` 2.14.1, noble 2.4.0 (lock has 2.2.0); 164 tests pass.

## Why

connectrpc 0.11.0 shipped on 2026-06-25 and broke every Python SDK request on fresh installs. Nothing in CI could see it because CI only tested `uv.lock`. With this in place the first red run would have opened an issue on 2026-06-26 instead of a client reporting it in September.

## Test plan

- [x] YAML parses; triggers, `if`, permissions, and the new step verified by loading the file
- [x] `workflow_dispatch` run on this branch passes: https://github.com/t-0-network/provider-sdk/actions/runs/33745282151 (both jobs green, the issue step skipped, no issue created)
- [x] No `pull_request` checks appear here because the workflow filters on `branches: [master]`; they will run once this is retargeted
- [x] `workflow_dispatch` run of `ci-node.yaml` on this branch passes: https://github.com/t-0-network/provider-sdk/actions/runs/33758873280 (both jobs green, issue step skipped, no issue created)
- [ ] After #298 merges, retarget this PR to `master` (GitHub does this automatically when the base branch is deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



