### PR TITLE
fix(node): export NetworkHeaders from /crypto subpath

### DIFF
--- a/node/sdk/README.md
+++ b/node/sdk/README.md
@@ -148,7 +148,7 @@ For custom proto registries (e.g. non-network schemas with custom predefined rul
 <details>
 <summary>Lower-level primitives</summary>
 
-The individual building blocks are also exported: `createRequestVerifier`, `rejectRequest`, `verifySignature`, `computeDigest`, `keccak256`, `parsePublicKey`, `publicKeysEqual`. You can import just the crypto module via the `./crypto` subpath: `import { createRequestVerifier } from "@t-0/provider-sdk/crypto"`.
+The individual building blocks are also exported: `createRequestVerifier`, `rejectRequest`, `verifySignature`, `computeDigest`, `keccak256`, `parsePublicKey`, `publicKeysEqual`, and the `NetworkHeaders` header-name enum. You can import just the crypto module via the `./crypto` subpath: `import { createRequestVerifier } from "@t-0/provider-sdk/crypto"`.
 </details>
 
 ### Network Client

--- a/node/sdk/src/crypto/index.ts
+++ b/node/sdk/src/crypto/index.ts
@@ -1,2 +1,3 @@
 export * from "../common/crypto/index.js";
 export { createRequestDecoder } from "../common/crypto/decode.js";
+export { default as NetworkHeaders } from "../common/headers.js";

--- a/node/sdk/test/crypto.test.ts
+++ b/node/sdk/test/crypto.test.ts
@@ -3,7 +3,7 @@ import * as nodeAssert from 'node:assert/strict';
 import { keccak_256 } from '@noble/hashes/sha3.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { CreateSigner } from '../src/client/signer.js';
-import { verifySignature, keccak256, computeDigest, parsePublicKey, publicKeysEqual, createRequestVerifier, DEFAULT_TOLERANCE_MS } from '../src/crypto/index.js';
+import { verifySignature, keccak256, computeDigest, parsePublicKey, publicKeysEqual, createRequestVerifier, DEFAULT_TOLERANCE_MS, NetworkHeaders } from '../src/crypto/index.js';
 import type { VerifyRequest } from '../src/crypto/index.js';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -817,6 +817,14 @@ describe('crypto/createRequestVerifier', () => {
       signatureHeader: '0x' + 'a'.repeat(127), // odd length
     }));
     nodeAssert.deepStrictEqual(result, { valid: false, reason: 'invalid_signature_format' });
+  });
+});
+
+describe('crypto/NetworkHeaders', () => {
+  it('is exported from the crypto subpath with the expected values', () => {
+    nodeAssert.equal(NetworkHeaders.PublicKey, 'X-Public-Key');
+    nodeAssert.equal(NetworkHeaders.Signature, 'X-Signature');
+    nodeAssert.equal(NetworkHeaders.SignatureTimestamp, 'X-Signature-Timestamp');
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #279.

- Export `NetworkHeaders` enum from the `/crypto` subpath (`@t-0/provider-sdk/crypto`), so consumers needing only crypto primitives no longer have to import from the main entry point (which pulls in `@connectrpc/connect-node` → `node:http`)
- Add test asserting `NetworkHeaders` is accessible with correct values from the crypto subpath
- Update README to mention `NetworkHeaders` in the lower-level primitives list

## Test plan

- [x] `npm run build` passes (ESM + CJS)
- [x] `npm test` — 165/165 tests pass, including new `crypto/NetworkHeaders` test
- [x] No circular dependencies introduced (`src/common/headers.ts` is a leaf module with zero imports)
- [x] Export pattern matches existing `src/index.ts` export (`export { default as NetworkHeaders }`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fftu1zkrxdwc53FSGr6sq