### PR TITLE
fix: make 0x prefix optional in hex headers + bump waitress

### DIFF
--- a/csharp/sdk/T0.ProviderSdk/Provider/SignatureVerificationMiddleware.cs
+++ b/csharp/sdk/T0.ProviderSdk/Provider/SignatureVerificationMiddleware.cs
@@ -106,7 +106,7 @@ public sealed class SignatureVerificationMiddleware
     }
 
     /// <summary>
-    /// Parses a hex-encoded header value (with 0x prefix). Returns null on failure.
+    /// Parses a hex-encoded header value (0x prefix optional). Returns null on failure.
     /// </summary>
     private static byte[]? ParseHexHeader(HttpContext context, string headerName)
     {
@@ -114,12 +114,17 @@ public sealed class SignatureVerificationMiddleware
         if (string.IsNullOrEmpty(headerValue))
             return null;
 
-        if (headerValue.Length < 2 || !headerValue.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        const string prefix = "0x";
+        var hex = headerValue.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? headerValue[prefix.Length..]
+            : headerValue;
+
+        if (hex.Length == 0)
             return null;
 
         try
         {
-            return Convert.FromHexString(headerValue[2..]);
+            return Convert.FromHexString(hex);
         }
         catch (FormatException)
         {

--- a/go/provider/verify_signature.go
+++ b/go/provider/verify_signature.go
@@ -98,11 +98,8 @@ func parseRequiredHexedHeader(headerName string, headers http.Header) ([]byte, e
 		return nil, fmt.Errorf("%w: %s", ErrMissingRequiredHeader, headerName)
 	}
 
-	if len(encodedHeader) < 2 {
-		return nil, fmt.Errorf("%w: %s", ErrInvalidHeaderEncoding, headerName)
-	}
-
-	decodedHeader, err := hex.DecodeString(encodedHeader[2:])
+	hexStr := strings.TrimPrefix(encodedHeader, "0x")
+	decodedHeader, err := hex.DecodeString(hexStr)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidHeaderEncoding, headerName)
 	}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -31,5 +31,5 @@ dev = [
     "ruff>=0.16.4",
     "mypy>=2.3.1",
     "uvicorn>=0.52.4",
-    "waitress>=3.0.0",
+    "waitress>=3.0.2",
 ]

--- a/python/sdk/src/t0_provider_sdk/provider/middleware.py
+++ b/python/sdk/src/t0_provider_sdk/provider/middleware.py
@@ -179,10 +179,11 @@ def _parse_hex_header(headers: dict[str, str], header_name: str) -> bytes:
     value = headers.get(header_key, "")
     if not value:
         raise MissingRequiredHeaderError(header_name)
-    if len(value) < 2:
+    hex_str = value.removeprefix("0x")
+    if not hex_str:
         raise InvalidHeaderEncodingError(header_name)
     try:
-        return bytes.fromhex(value[2:])  # strip "0x"
+        return bytes.fromhex(hex_str)
     except ValueError:
         raise InvalidHeaderEncodingError(header_name)
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -593,7 +593,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "ruff", specifier = ">=0.16.4" },
     { name = "uvicorn", specifier = ">=0.52.4" },
-    { name = "waitress", specifier = ">=3.0.0" },
+    { name = "waitress", specifier = ">=3.0.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Fix #205** — Make `0x` prefix optional in hex header parsing across Go, Python, and C#. Node and Java already handled it correctly. All five SDKs now strip-if-present consistently.
- **Bump `waitress` floor** from `>=3.0.0` to `>=3.0.2`

### Hex prefix handling before/after

| SDK | Before | After |
|-----|--------|-------|
| Go | `encodedHeader[2:]` — unconditionally stripped first 2 chars | `strings.TrimPrefix(encodedHeader, "0x")` |
| Python | `value[2:]` — unconditionally stripped first 2 chars | `value.removeprefix("0x")` |
| C# | Required `0x`, rejected bare hex | `StartsWith("0x") ? [2..] : value` |
| Node | Strip if present | No change needed |
| Java | `stripHexPrefix` — strip if present | No change needed |

A caller sending a bare hex key (no `0x` prefix) previously got a misleading "malformed public key" error from Go/Python (lost a byte), or a silent rejection from C#.

## Test plan

- [x] `go vet ./... && go test ./...` — all pass
- [x] Python 132/132 pass
- [x] C# 67/67 pass
- [x] Cross-language tests unaffected (all SDKs emit `0x` prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Yb7GDcNeg6SfnjC1i9AUK
