### PR TITLE
fix: cross-test coverage, body size alignment (10 MiB), C# timestamp tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ All languages share `cross_test/test_vectors.json` for crypto compatibility (Kec
 
 ### Server-to-server cross-tests
 
-A shared Go helper at `cross_test/go_helper/` exercises bidirectional server-to-server communication (health check round-trips, PayOut where applicable) between each SDK and Go. Every SDK's CI workflow builds the helper automatically.
+A shared Go helper at `cross_test/go_helper/` exercises bidirectional server-to-server communication (health check round-trips with non-empty body) between each SDK and Go. Every SDK's CI workflow builds the helper automatically. Health checks with `service="grpc.health.v1.Health"` produce a ~23-byte protobuf body, which is sufficient for signature-over-real-body testing — the signing scheme hashes the body into a fixed 32-byte Keccak-256 digest regardless of size. PayOut tests exist in some SDKs for historical reasons but are not required for crypto interop coverage.
 
 ```bash
 cd cross_test/go_helper && go build -o go_helper .   # Build once
@@ -65,7 +65,7 @@ cd java && ./gradlew test --tests "*.CrossServerTests" # Java ↔ Go
 ```
 
 **When adding a new SDK**, add cross-language server-to-server tests that use `cross_test/go_helper/`:
-1. Create test file(s) that start/call the Go helper for bidirectional PayOut + health round-trips
+1. Create test file(s) that start/call the Go helper for bidirectional health round-trips (with `service` field set for non-empty body)
 2. Add Go setup + helper build to the SDK's CI workflow (see `ci-python.yaml` for pattern)
 3. Add `go/**` and `cross_test/**` to the CI workflow's path triggers
 4. In CI, tests must **fail** (not skip) if the helper binary is missing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,19 @@ cd java && ./gradlew test --tests "*.CrossServerTests" # Java ↔ Go
 3. Add `go/**` and `cross_test/**` to the CI workflow's path triggers
 4. In CI, tests must **fail** (not skip) if the helper binary is missing
 
+## Definition of Done
+
+Before a change is considered complete, cross-language tests must pass:
+
+```bash
+cd cross_test/go_helper && go build -o go_helper .   # Rebuild helper
+cd go && go vet ./... && go test ./...                # Go
+cd node/sdk && npm ci && npm run build && npm test    # Node (includes cross-tests)
+cd python && uv run pytest tests/cross_test/ -v       # Python ↔ Go
+cd csharp && dotnet test --filter "CrossServerTests"  # C# ↔ Go
+cd java && ./gradlew test --tests "*.CrossServerTests" # Java ↔ Go
+```
+
 ## Signature Protocol
 
 ```
@@ -84,7 +97,7 @@ headers = { X-Public-Key: "0x...", X-Signature: "0x...", X-Signature-Timestamp: 
 
 ### body_bytes framing — depends on signer position
 
-`body_bytes` is whichever bytes the signer covers at its own layer. For SDK clients in this repo and Connect-protocol callers in general, that is **unframed protobuf** (the Java SDK's `NetworkClient` signs above the gRPC framer; Go / Node / Python use Connect protocol, where no frame exists). The T-0 Network signs unframed bytes when calling a provider via Connect protocol, and signs the **gRPC-framed body** (5-byte prefix + protobuf) when calling via gRPC protocol — in that case the signer sits below the framer.
+`body_bytes` is whichever bytes the signer covers at its own layer. For most SDK clients in this repo and Connect-protocol callers in general, that is **unframed protobuf** (the Java SDK's `NetworkClient` signs above the gRPC framer; Go / Node / Python use Connect protocol, where no frame exists). The exception is C#: its `SigningDelegatingHandler` sits below the gRPC framer in the HttpClient pipeline, so it signs the **gRPC-framed body** — matching Go's primary verification path, not the fallback. The T-0 Network signs unframed bytes when calling a provider via Connect protocol, and signs the **gRPC-framed body** (5-byte prefix + protobuf) when calling via gRPC protocol — in that case the signer sits below the framer.
 
 Consequently the Java SDK's `SignatureVerificationInterceptor` accepts both framings. **This dual-path is required, not defensive** — see [`docs/java/SIGNATURE_VERIFICATION.md`](docs/java/SIGNATURE_VERIFICATION.md) before touching it.
 

--- a/cross_test/README.md
+++ b/cross_test/README.md
@@ -80,7 +80,7 @@ CI builds the helper automatically (each language's CI workflow sets up Go and b
 | `verify <hex_public_key> <hex_digest> <hex_signature>` | Verify signature |
 | `pubkey <hex_private_key>` | Derive public key |
 | `serve <port> <hex_public_key>` | Provider server (h2c, Connect + gRPC) |
-| `call-pay-out <url> <hex_private_key> <hex_public_key> [--grpc]` | Signed PayOut RPC |
+| `call-pay-out <url> <hex_private_key> [--grpc]` | Signed PayOut RPC |
 | `call-health <url> <hex_private_key> [--grpc]` | Signed health check |
 
 Default protocol is Connect (HTTP/1.1). Pass `--grpc` for gRPC protocol over h2c.

--- a/cross_test/go_helper/main.go
+++ b/cross_test/go_helper/main.go
@@ -8,7 +8,7 @@
 //	go_helper verify <hex_public_key> <hex_digest> <hex_signature>
 //	go_helper pubkey <hex_private_key>
 //	go_helper serve <port> <hex_network_public_key>
-//	go_helper call-pay-out <base_url> <hex_private_key> <hex_network_public_key> [--grpc]
+//	go_helper call-pay-out <base_url> <hex_private_key> [--grpc]
 //	go_helper call-health <base_url> <hex_private_key> [--grpc]
 package main
 
@@ -175,20 +175,19 @@ func hasFlag(flag string) bool {
 
 func cmdCallPayOut() {
 	grpcMode := hasFlag("--grpc")
-	// Positional: call-pay-out <base_url> <hex_private_key> <hex_network_public_key> [--grpc]
-	positional := make([]string, 0, 3)
+	// Positional: call-pay-out <base_url> <hex_private_key> [--grpc]
+	positional := make([]string, 0, 2)
 	for _, arg := range os.Args[2:] {
 		if !strings.HasPrefix(arg, "--") {
 			positional = append(positional, arg)
 		}
 	}
-	if len(positional) != 3 {
-		fmt.Fprintln(os.Stderr, "Usage: go_helper call-pay-out <base_url> <hex_private_key> <hex_network_public_key> [--grpc]")
+	if len(positional) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go_helper call-pay-out <base_url> <hex_private_key> [--grpc]")
 		os.Exit(1)
 	}
 	baseURL := positional[0]
 	privateKey := network.PrivateKeyHexed(positional[1])
-	_ = positional[2] // network public key (used by server, not client)
 
 	var clientOpts []network.ClientOption
 	clientOpts = append(clientOpts, network.WithBaseURL(baseURL))
@@ -263,7 +262,7 @@ func cmdCallHealth() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	resp, err := client.Check(ctx, &grpchealth.CheckRequest{})
+	resp, err := client.Check(ctx, &grpchealth.CheckRequest{Service: grpchealth.HealthV1ServiceName})
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
 		os.Exit(1)

--- a/csharp/sdk/T0.ProviderSdk.Tests/CrossTest/CrossServerTests.cs
+++ b/csharp/sdk/T0.ProviderSdk.Tests/CrossTest/CrossServerTests.cs
@@ -112,7 +112,6 @@ public class CrossServerTests
                         "call-pay-out",
                         $"http://127.0.0.1:{port}",
                         PrivateKey,
-                        PublicKey,
                         "--grpc",
                     },
                     RedirectStandardOutput = true,
@@ -261,7 +260,7 @@ public class CrossServerTests
             var healthClient = new Grpc.Health.V1.Health.HealthClient(channel);
 
             var response = await healthClient.CheckAsync(
-                new Grpc.Health.V1.HealthCheckRequest());
+                new Grpc.Health.V1.HealthCheckRequest { Service = Grpc.Health.V1.Health.Descriptor.FullName });
 
             Assert.Equal(Grpc.Health.V1.HealthCheckResponse.Types.ServingStatus.Serving, response.Status);
         }

--- a/csharp/sdk/T0.ProviderSdk.Tests/Provider/SignatureVerificationMiddlewareTests.cs
+++ b/csharp/sdk/T0.ProviderSdk.Tests/Provider/SignatureVerificationMiddlewareTests.cs
@@ -66,16 +66,23 @@ public class SignatureVerificationMiddlewareTests
         Assert.Equal("3", context.Response.Headers["grpc-status"].ToString()); // InvalidArgument = 3
     }
 
-    [Fact]
-    public async Task TimestampOutOfRange_ShouldReturnError()
+    [Theory]
+    [InlineData(-120_000, false)]  // 2 min past → reject
+    [InlineData(-60_001, false)]   // just past boundary → reject
+    [InlineData(-60_000, true)]    // exact boundary → accept
+    [InlineData(0, true)]          // now → accept
+    [InlineData(60_000, true)]     // exact boundary → accept
+    [InlineData(60_001, false)]    // just past boundary → reject
+    [InlineData(120_000, false)]   // 2 min future → reject
+    public async Task TimestampBoundary_ShouldRejectOutsideWindow(long offsetMs, bool shouldPass)
     {
         var body = "test"u8.ToArray();
         var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        var oldTimestamp = now - 120_000; // 2 minutes old
+        var requestTimestamp = now + offsetMs;
         var timeProvider = new FakeTimeProvider(DateTimeOffset.FromUnixTimeMilliseconds(now));
 
         var tsBytes = new byte[8];
-        BinaryPrimitives.WriteUInt64LittleEndian(tsBytes, (ulong)oldTimestamp);
+        BinaryPrimitives.WriteUInt64LittleEndian(tsBytes, (ulong)requestTimestamp);
         var digest = Keccak256.Hash(body, tsBytes);
         var result = _signer.Sign(digest);
 
@@ -85,10 +92,14 @@ public class SignatureVerificationMiddlewareTests
             CreateOptions(),
             timeProvider);
 
-        var context = CreateContext(body, result.SignatureHex, result.PublicKeyHex, oldTimestamp);
+        var context = CreateContext(body, result.SignatureHex, result.PublicKeyHex, requestTimestamp);
         await middleware.InvokeAsync(context);
 
-        Assert.False(handlerCalled);
+        Assert.Equal(shouldPass, handlerCalled);
+        if (!shouldPass)
+        {
+            Assert.Equal("3", context.Response.Headers["grpc-status"].ToString());
+        }
     }
 
     [Fact]

--- a/csharp/sdk/T0.ProviderSdk/Provider/ProviderServerOptions.cs
+++ b/csharp/sdk/T0.ProviderSdk/Provider/ProviderServerOptions.cs
@@ -12,7 +12,7 @@ public sealed class ProviderServerOptions
     public string NetworkPublicKeyHex { get; set; } = "";
 
     /// <summary>
-    /// Maximum request body size in bytes. Default: 1 MB.
+    /// Maximum request body size in bytes. Default: 10 MiB.
     /// </summary>
-    public long MaxBodySize { get; set; } = 1_048_576;
+    public long MaxBodySize { get; set; } = 10 * 1024 * 1024;
 }

--- a/csharp/sdk/T0.ProviderSdk/T0ProviderServer.cs
+++ b/csharp/sdk/T0.ProviderSdk/T0ProviderServer.cs
@@ -33,6 +33,7 @@ public sealed class T0ProviderServer
         _builder.WebHost.UseUrls($"http://0.0.0.0:{config.Port}");
         _builder.Services.AddGrpc(options =>
         {
+            options.MaxReceiveMessageSize = 10 * 1024 * 1024; // 10 MiB, matching signature verification cap
             options.Interceptors.Add<ValidationInterceptor>();
         });
         _builder.Services.AddSingleton<ISigner>(signer);

--- a/docs/CROSS_LANGUAGE_TESTING.md
+++ b/docs/CROSS_LANGUAGE_TESTING.md
@@ -77,7 +77,7 @@ Tests **fail** (not skip) if the Go helper binary is missing in CI.
 
 ## Adding a new SDK
 
-1. Create test files that start/call the Go helper for bidirectional health + PayOut round-trips
+1. Create test files that start/call the Go helper for bidirectional health round-trips (with `service` field set for non-empty body)
 2. Add Go setup + helper build to the SDK's CI workflow (see `ci-python.yaml` for the pattern)
 3. Add `go/**` and `cross_test/**` to the CI workflow's path triggers
 4. Tests must fail (not skip) if the helper binary is missing in CI

--- a/docs/CROSS_LANGUAGE_TESTING.md
+++ b/docs/CROSS_LANGUAGE_TESTING.md
@@ -37,7 +37,7 @@ CI builds it automatically (each language's CI workflow sets up Go and builds it
 | `verify <hex_public_key> <hex_digest> <hex_signature>` | Verify signature |
 | `pubkey <hex_private_key>` | Derive public key |
 | `serve <port> <hex_public_key>` | Start a provider server (h2c, Connect + gRPC) |
-| `call-pay-out <url> <key> <pubkey> [--grpc]` | Signed PayOut RPC |
+| `call-pay-out <url> <key> [--grpc]` | Signed PayOut RPC |
 | `call-health <url> <key> [--grpc]` | Signed health check |
 
 Default protocol is Connect (HTTP/1.1). Pass `--grpc` for gRPC protocol over h2c.
@@ -61,7 +61,7 @@ Default protocol is Connect (HTTP/1.1). Pass `--grpc` for gRPC protocol over h2c
 
 ## Dual-framing (gRPC interop)
 
-The Go server's signature verification middleware accepts signatures over both gRPC-framed and unframed protobuf bodies. This enables Java and C# gRPC clients (which sign above the gRPC framer) to interoperate with the Go server (which reads the gRPC-framed HTTP body).
+The Go server's signature verification middleware accepts signatures over both gRPC-framed and unframed protobuf bodies. This enables Java gRPC clients (whose `SigningClientInterceptor` signs above the gRPC framer) to interoperate with the Go server (which reads the gRPC-framed HTTP body). C# clients sign the framed body (`SigningDelegatingHandler` sits below the gRPC framer in the HttpClient pipeline) and pass on the primary verification path.
 
 The fallback logic: try full body first; if that fails AND the request is `application/grpc` with a valid 5-byte gRPC frame prefix, strip the prefix and retry. See `go/provider/verify_signature.go`.
 

--- a/docs/java/ISSUES_AND_LESSONS.md
+++ b/docs/java/ISSUES_AND_LESSONS.md
@@ -4,7 +4,7 @@ Historical issues encountered during development, extracted from git history. Or
 
 ## Near-Miss: Removing dual-framing signature verification (issue #89)
 
-**Problem:** A cross-language code review flagged the dual-path verification in `SignatureVerificationInterceptor.verifySignature` (tries unframed first, then gRPC-framed) as architecturally fragile and possibly dead code, since all four SDK clients shipped in this repo sign unframed bytes. Issue #89 proposed investigation before removal.
+**Problem:** A cross-language code review flagged the dual-path verification in `SignatureVerificationInterceptor.verifySignature` (tries unframed first, then gRPC-framed) as architecturally fragile and possibly dead code, since most SDK clients shipped in this repo sign unframed bytes. Issue #89 proposed investigation before removal.
 
 **Root cause of confusion:** The survey covered only the SDK clients in this repo. It missed that the T-0 Network is itself a signing party calling providers, and that the network's signed payload depends on the transport configured for the provider — for Connect protocol it signs unframed bytes, for gRPC protocol it signs the gRPC-framed body (5-byte frame prefix + protobuf). The framed verification path is therefore alive in production whenever the network is configured to call a provider via gRPC protocol.
 

--- a/docs/java/SIGNATURE_VERIFICATION.md
+++ b/docs/java/SIGNATURE_VERIFICATION.md
@@ -73,13 +73,13 @@ Removing path 1 silently breaks every caller whose signing wiring is above the f
 
 In both cases the failure surfaces only as `UNAUTHENTICATED` responses for one class of caller, not the other — the kind of stealth breakage that is hard to attribute and easy to misdiagnose.
 
-GitHub issue [#89](https://github.com/t-0-network/provider-sdk/issues/89) raised concern that the framed path looked like dead code because the SDK clients shipped in this repo all sign unframed. The audit was incomplete — it considered only same-repo SDK clients and missed the network's gRPC-protocol path, which signs framed bodies. Both framings are required.
+GitHub issue [#89](https://github.com/t-0-network/provider-sdk/issues/89) raised concern that the framed path looked like dead code because most SDK clients shipped in this repo sign unframed. The audit was incomplete — it considered only same-repo SDK clients and missed the network's gRPC-protocol path, which signs framed bodies. Additionally, the C# SDK's `SigningDelegatingHandler` signs the framed body (it sits below the gRPC framer in the HttpClient pipeline), so it also exercises the framed path. Both framings are required.
 
 ## Conditions under which simplification would be safe
 
 A single canonical framing could be enforced only if **all** signing parties that talk to a Java provider can be confirmed to sign at the same layer. That confirmation must include:
 
-- All four SDK clients in this repo (currently all sign unframed).
+- All five SDK clients in this repo (Java signs unframed; C# signs framed; Go/Node/Python use Connect protocol with no frame).
 - The network for every transport configuration it can be set to use against the provider.
 - Any third-party client built directly on a gRPC framework, where the integrator chose where to wire signing.
 

--- a/docs/python/ARCHITECTURE.md
+++ b/docs/python/ARCHITECTURE.md
@@ -927,13 +927,13 @@ Tests use shared test vectors from the Go SDK to ensure cross-language compatibi
 
 Located in `tests/cross_test/`, these tests validate interoperability between the Python and Go SDKs using a small Go helper binary.
 
-**Go helper binary** (`tests/cross_test/go_helper/`):
+**Go helper binary** (`cross_test/go_helper/`):
 - `hash <hex_data>` -- Compute Keccak-256
 - `sign <hex_private_key> <hex_digest>` -- Sign a digest
 - `verify <hex_public_key> <hex_digest> <hex_signature>` -- Verify a signature
 - `pubkey <hex_private_key>` -- Derive public key
 - `serve <port> <hex_network_public_key>` -- Start a Go ProviderService server
-- `call-pay-out <base_url> <hex_private_key> <hex_network_public_key>` -- Call PayOut on a server
+- `call-pay-out <base_url> <hex_private_key>` -- Call PayOut on a server
 
 **Signature cross-tests** (`test_cross_signature.py`):
 - Keccak-256 hash consistency between Python and Go
@@ -960,7 +960,7 @@ uv run pytest -v
 uv run pytest sdk/tests -v
 
 # Run cross-language tests (requires Go helper binary)
-cd tests/cross_test/go_helper && go build -o go_helper . && cd ../../..
+cd ../cross_test/go_helper && go build -o go_helper . && cd ../../python
 uv run pytest tests/cross_test -v
 
 # Lint

--- a/go/CLAUDE.md
+++ b/go/CLAUDE.md
@@ -10,10 +10,10 @@ Protobuf encoding is not canonical — re-encoding a deserialized message produc
 
 `verify_signature.go`'s middleware accepts signatures over **either** the full HTTP body **or** the body with the 5-byte gRPC frame prefix stripped. Both paths are required:
 
-- **Full body** — Connect-protocol callers (Go, Node, Python) and any signer that covers the on-wire bytes.
-- **Unframed fallback** — gRPC-protocol callers whose signing interceptor sits above the gRPC framer (Java SDK's `SigningClientInterceptor`, C# SDK's `SigningDelegatingHandler`). The signed payload is unframed protobuf, but the HTTP body includes the gRPC frame prefix.
+- **Full body** — Connect-protocol callers (Go, Node, Python) and gRPC-protocol callers whose signer covers the framed body (C# SDK's `SigningDelegatingHandler` sits below the gRPC framer in the HttpClient pipeline, so it signs the already-framed bytes).
+- **Unframed fallback** — gRPC-protocol callers whose signing interceptor sits above the gRPC framer (Java SDK's `SigningClientInterceptor`). The signed payload is unframed protobuf, but the HTTP body includes the gRPC frame prefix.
 
-Removing the fallback silently breaks Java and C# SDK clients with `UNAUTHENTICATED`. The Java SDK has the same dual-path on its server side — see [`docs/java/SIGNATURE_VERIFICATION.md`](../docs/java/SIGNATURE_VERIFICATION.md).
+Removing the fallback silently breaks **Java SDK** clients with `UNAUTHENTICATED`. The Java SDK has the same dual-path on its server side — see [`docs/java/SIGNATURE_VERIFICATION.md`](../docs/java/SIGNATURE_VERIFICATION.md).
 
 ## Build Commands
 

--- a/go/network/client_test.go
+++ b/go/network/client_test.go
@@ -191,13 +191,15 @@ func TestSigningTransport_NilAndNoBodyProduceSameSignature(t *testing.T) {
 
 	st := NewSigningTransport(signFn, func() time.Time { return fixedTime }, WithTransport(recorder))
 
-	reqNil, _ := http.NewRequest("POST", "http://localhost/test", nil)
+	reqNil, err := http.NewRequest("POST", "http://localhost/test", nil)
+	require.NoError(t, err)
 	resp, err := st.RoundTrip(reqNil)
 	require.NoError(t, err)
 	resp.Body.Close()
 	sigNil = reqNil.Header.Get(common.SignatureHeader)
 
-	reqNoBody, _ := http.NewRequest("POST", "http://localhost/test", http.NoBody)
+	reqNoBody, err := http.NewRequest("POST", "http://localhost/test", http.NoBody)
+	require.NoError(t, err)
 	resp, err = st.RoundTrip(reqNoBody)
 	require.NoError(t, err)
 	resp.Body.Close()

--- a/go/provider/handler_option.go
+++ b/go/provider/handler_option.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	defaultMaxBodySize = 1024 * 1024 // 1 MB
+	defaultMaxBodySize = 10 * 1024 * 1024 // 10 MiB
 )
 
 type providerHandlerOptions struct {

--- a/go/provider/verify_signature.go
+++ b/go/provider/verify_signature.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -80,19 +81,7 @@ func newSignatureVerifierMiddleware(
 			_ = req.Body.Close()
 			req.Body = io.NopCloser(bytes.NewReader(body))
 
-			if err := verifySignature(publicKey, append(body, timestampBytes[:]...), signature); err != nil {
-				// gRPC clients (e.g. Java SDK) sign above the gRPC framer — the
-				// signed payload is unframed protobuf. When the request arrives via
-				// gRPC protocol the HTTP body includes a 5-byte frame prefix the
-				// signer never saw. Try again without it.
-				if isGRPCRequest(req) && hasGRPCFramePrefix(body) {
-					unframed := body[5:]
-					if err2 := verifySignature(publicKey, append(unframed, timestampBytes[:]...), signature); err2 == nil {
-						ctx := context.WithValue(req.Context(), signatureErrorContextKey{}, (*SignatureError)(nil))
-						handler.ServeHTTP(writer, req.WithContext(ctx))
-						return
-					}
-				}
+			if err := verifyWithFramingFallback(verifySignature, req, publicKey, body, signature, timestampBytes); err != nil {
 				setErrorAndContinue(req, connect.CodeUnauthenticated, err.Error())
 				return
 			}
@@ -200,9 +189,25 @@ func timesWithinDelta(t1, t2 time.Time, delta time.Duration) bool {
 	return diff <= delta
 }
 
+// verifyWithFramingFallback tries the full body first; if that fails and the
+// request is gRPC with a valid frame prefix, retries without the 5-byte prefix.
+// Required for Java SDK clients whose SigningClientInterceptor signs above the
+// gRPC framer. See go/CLAUDE.md "Dual Framing" section.
+func verifyWithFramingFallback(verify VerifySignature, req *http.Request, publicKey, body, signature []byte, timestampBytes [8]byte) error {
+	err := verify(publicKey, append(body, timestampBytes[:]...), signature)
+	if err == nil {
+		return nil
+	}
+	if isGRPCRequest(req) && hasGRPCFramePrefix(body) {
+		if verify(publicKey, append(body[5:], timestampBytes[:]...), signature) == nil {
+			return nil
+		}
+	}
+	return err
+}
+
 func isGRPCRequest(req *http.Request) bool {
-	ct := req.Header.Get("Content-Type")
-	return len(ct) >= 16 && ct[:16] == "application/grpc"
+	return strings.HasPrefix(req.Header.Get("Content-Type"), "application/grpc")
 }
 
 func hasGRPCFramePrefix(body []byte) bool {

--- a/java/sdk/src/main/java/network/t0/sdk/provider/ProviderServer.java
+++ b/java/sdk/src/main/java/network/t0/sdk/provider/ProviderServer.java
@@ -172,7 +172,7 @@ public final class ProviderServer implements Closeable {
         private final int port;
         private final String networkPublicKey;
         private final List<BindableService> services = new ArrayList<>();
-        private int maxInboundMessageSize = 4 * 1024 * 1024; // 4MB default
+        private int maxInboundMessageSize = 10 * 1024 * 1024; // 10 MiB default
         private int maxInboundMetadataSize = 8192; // 8KB default
         private long handshakeTimeout = 120;
         private TimeUnit handshakeTimeoutUnit = TimeUnit.SECONDS;

--- a/java/sdk/src/test/java/network/t0/sdk/integration/CrossServerTests.java
+++ b/java/sdk/src/test/java/network/t0/sdk/integration/CrossServerTests.java
@@ -86,7 +86,7 @@ class CrossServerTests {
                     HealthGrpc::newBlockingStub)) {
 
                 HealthCheckResponse response = client.stub()
-                        .check(HealthCheckRequest.getDefaultInstance());
+                        .check(HealthCheckRequest.newBuilder().setService(HealthGrpc.SERVICE_NAME).build());
 
                 assertThat(response.getStatus())
                         .isEqualTo(HealthCheckResponse.ServingStatus.SERVING);
@@ -185,7 +185,6 @@ class CrossServerTests {
                     "call-pay-out",
                     "http://127.0.0.1:" + port,
                     "0x" + PRIVATE_KEY,
-                    "0x" + PUBLIC_KEY,
                     "--grpc")
                     .redirectErrorStream(false)
                     .start();

--- a/node/sdk/src/common/service.ts
+++ b/node/sdk/src/common/service.ts
@@ -39,9 +39,16 @@ export interface CreateServiceOptions {
    * header. Omit to suppress the header.
    */
   version?: string;
+
+  /**
+   * Maximum request body size in bytes. Default: 10 MiB.
+   * Requests exceeding this limit are rejected before signature verification.
+   */
+  maxBodySize?: number;
 }
 
 export const REQUEST_VALIDITY_MILLIS = 60_000;
+export const DEFAULT_MAX_BODY_SIZE = 10 * 1024 * 1024; // 10 MiB
 
 const createSignatureVerification: (networkPublicKey: Buffer) => Interceptor = (networkPublicKey: Buffer) => (next) => async (req) => {
   const ts = decodeNum(getHeader(req, NetworkHeaders.SignatureTimestamp));
@@ -101,6 +108,7 @@ export const createService = (
       origService(Health, createHealthServiceImpl(collected, options?.version));
     },
     interceptors: [createSignatureVerification(networkPublicKey), createValidationInterceptor({ logger: options?.logger, registry: options?.registry })],
+    readMaxBytes: options?.maxBodySize ?? DEFAULT_MAX_BODY_SIZE,
     grpcWeb: false,
     contextValues: (req: any) => {
       return createContextValues().set(kHash, (req as any).hasher as Hash<Hash<any>>)

--- a/node/sdk/test/cross_server.test.ts
+++ b/node/sdk/test/cross_server.test.ts
@@ -80,7 +80,7 @@ describe('Cross-language: Node ↔ Go', { skip: !goAvailable() ? `Go helper not 
         await waitForPort(port);
 
         const client = createClient(CLIENT_PRIVATE_KEY, `http://127.0.0.1:${port}`, Health);
-        const resp = await client.check({ service: '' });
+        const resp = await client.check({ service: Health.typeName });
         assert.ok(resp, 'Health check response should not be null');
       } finally {
         goServer.kill();

--- a/python/sdk/src/t0_provider_sdk/provider/health.py
+++ b/python/sdk/src/t0_provider_sdk/provider/health.py
@@ -25,7 +25,7 @@ from collections.abc import Iterable, Mapping
 
 from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
-from connectrpc.compat import google_protobuf_codecs
+from connectrpc.compat import google_protobuf_binary_codec, google_protobuf_codecs
 from connectrpc.errors import ConnectError
 from connectrpc.interceptor import Interceptor, InterceptorSync
 from connectrpc.method import IdempotencyLevel, MethodInfo
@@ -136,6 +136,9 @@ class HealthWSGIApplication(ConnectWSGIApplication):
 class HealthClient(ConnectClient):
     """Async health check client."""
 
+    def __init__(self, address: str, **kwargs: object) -> None:
+        super().__init__(address, codec=google_protobuf_binary_codec(), **kwargs)
+
     async def check(
         self,
         request: health_pb2.HealthCheckRequest | None = None,
@@ -155,6 +158,9 @@ class HealthClient(ConnectClient):
 
 class HealthClientSync(ConnectClientSync):
     """Sync health check client."""
+
+    def __init__(self, address: str, **kwargs: object) -> None:
+        super().__init__(address, codec=google_protobuf_binary_codec(), **kwargs)
 
     def check(
         self,

--- a/python/sdk/src/t0_provider_sdk/provider/middleware.py
+++ b/python/sdk/src/t0_provider_sdk/provider/middleware.py
@@ -50,8 +50,8 @@ signature_error_var: contextvars.ContextVar[SignatureVerificationError | None] =
     "signature_error", default=None
 )
 
-# Default max body size (4 MB), matching Go SDK
-DEFAULT_MAX_BODY_SIZE = 4 * 1024 * 1024
+# Default max body size (10 MiB), matching Go SDK and T-0 Network
+DEFAULT_MAX_BODY_SIZE = 10 * 1024 * 1024
 
 # Timestamp tolerance: ±60 seconds
 TIMESTAMP_TOLERANCE_MS = 60_000

--- a/python/tests/cross_test/test_cross_server.py
+++ b/python/tests/cross_test/test_cross_server.py
@@ -36,7 +36,7 @@ from t0_provider_sdk.api.tzero.v1.payment.provider_pb2 import (
 )
 from t0_provider_sdk.network.client import new_service_client
 from t0_provider_sdk.provider.handler import handler, new_asgi_app
-from t0_provider_sdk.provider.health import HealthClient
+from t0_provider_sdk.provider.health import HEALTH_SERVICE_FQN, HealthClient
 
 GO_HELPER = Path(__file__).resolve().parents[3] / "cross_test" / "go_helper" / "go_helper"
 
@@ -176,7 +176,7 @@ class TestPythonClientGoServerHealth:
                 HealthClient,
                 base_url=f"http://127.0.0.1:{port}",
             )
-            response = await client.check(health_pb2.HealthCheckRequest())
+            response = await client.check(health_pb2.HealthCheckRequest(service=HEALTH_SERVICE_FQN))
             assert response.status == health_pb2.HealthCheckResponse.SERVING
         finally:
             proc.terminate()

--- a/python/tests/cross_test/test_cross_server_sync.py
+++ b/python/tests/cross_test/test_cross_server_sync.py
@@ -36,7 +36,7 @@ from t0_provider_sdk.api.tzero.v1.payment.provider_pb2 import (
 )
 from t0_provider_sdk.network.client import new_service_client_sync
 from t0_provider_sdk.provider.handler import handler_sync, new_wsgi_app
-from t0_provider_sdk.provider.health import HealthClientSync
+from t0_provider_sdk.provider.health import HEALTH_SERVICE_FQN, HealthClientSync
 
 GO_HELPER = Path(__file__).resolve().parents[3] / "cross_test" / "go_helper" / "go_helper"
 
@@ -161,7 +161,7 @@ class TestPythonClientGoServerHealthSync:
                 HealthClientSync,
                 base_url=f"http://127.0.0.1:{port}",
             )
-            response = client.check(health_pb2.HealthCheckRequest())
+            response = client.check(health_pb2.HealthCheckRequest(service=HEALTH_SERVICE_FQN))
             assert response.status == health_pb2.HealthCheckResponse.SERVING
         finally:
             proc.terminate()


### PR DESCRIPTION
## Summary

### Cross-test coverage gaps (from PR #301 review)
- **F4** — Extract `verifyWithFramingFallback` helper in Go's `verify_signature.go`; replace manual string slicing with `strings.HasPrefix`
- **F6** — Fix silenced `http.NewRequest` errors in `go/network/client_test.go`
- **F5** — Remove unused `<hex_network_public_key>` param from `go_helper call-pay-out` + all callers + docs
- **F1** — Set `service` field to `"grpc.health.v1.Health"` in all cross-test health checks (was empty/0-byte body)
- **F3** — Correct docs that wrongly said C# needs the unframed fallback (empirical probe confirmed C# signs framed body)

### Python health client codec fix
- `HealthClient`/`HealthClientSync` were missing `google_protobuf_binary_codec`, making them unusable on `connectrpc >= 0.11` (pre-existing bug missed by PR #298)

### Align default max body size to 10 MiB across all SDKs (closes #307)
| SDK | Before | After |
|-----|--------|-------|
| Go | 1 MB | 10 MiB |
| Python | 4 MB | 10 MiB |
| Node | **unlimited** | 10 MiB |
| Java | 4 MB | 10 MiB |
| C# | 1 MB | 10 MiB |

Node had no body size cap at all — a malicious client could OOM the server. Now uses connect-node's `readMaxBytes`, configurable via `CreateServiceOptions.maxBodySize`.

### C# timestamp-boundary tests (closes #306)
xUnit Theory with 7 cases covering exact ±60s boundary, inside/outside window, asserting both handler invocation and grpc-status code.

### Documentation
- Clarify health checks are sufficient for crypto cross-tests (not PayOut)
- Add "Definition of Done" section requiring cross-language tests to pass
- Fix stale paths in `docs/python/ARCHITECTURE.md`
- Correct C# framing claims in 6 doc files

## Test plan

- [x] `go vet ./... && go test ./...` — all pass
- [x] Node — 166/166 pass
- [x] C# — 11/11 pass (including 7 new timestamp boundary cases)
- [x] Python — 132/132 pass (including previously broken health client tests)
- [x] Java cross-tests — 4/4 pass
- [x] C# cross-tests — 3/3 pass

## Reviews

- **Fable**: APPROVE — 3 follow-ups all addressed
- **Codex**: No functional defects — 2 doc issues addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Yb7GDcNeg6SfnjC1i9AUK
