### PR TITLE
chore(ci): Enable Gradle caching in Java CI

### DIFF
--- a/.github/workflows/ci-java.yaml
+++ b/.github/workflows/ci-java.yaml
@@ -54,8 +54,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-disabled: true
 
       - name: Build and test
         working-directory: java


### PR DESCRIPTION
## Summary
- Remove `cache-disabled: true` from `gradle/actions/setup-gradle@v6` in `ci-java.yaml`
- Enables caching of Gradle distribution (~145 MB) and Maven Central dependencies between CI runs
- On `master` pushes: saves + restores cache; on PR branches: restore-only (reads master's cache, doesn't pollute it)

## Test plan
- [ ] Verify "Setup Gradle" step output shows "Restoring Gradle User Home" instead of "Cache is disabled"
- [ ] Verify "Build and test" step no longer downloads `gradle-9.7.1-bin.zip` on warm cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfipXzLGKsWuyLdDjUGRYy