### PR TITLE
fix(ci): Add Go cross-test helper to release workflow

### DIFF
--- a/.github/workflows/ci-java.yaml
+++ b/.github/workflows/ci-java.yaml
@@ -54,8 +54,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-disabled: true
 
       - name: Build and test
         working-directory: java

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,10 +74,24 @@ jobs:
           java-version: "17"
           distribution: "temurin"
 
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "stable"
+          cache-dependency-path: cross_test/go_helper/go.sum
+
+      - name: Cache Go cross-test helper
+        uses: actions/cache@v4
+        with:
+          path: cross_test/go_helper/go_helper
+          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
+
+      - name: Build Go cross-test helper
+        working-directory: cross_test/go_helper
+        run: go build -o go_helper .
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-disabled: true
 
       - name: Build
         working-directory: java


### PR DESCRIPTION
## Summary
- Add Go setup + cross-test helper build to release workflow's `build-java` job
- The release workflow was missing these steps that `ci-java.yaml` has, causing all 4 CrossServerTests to fail during release
- Also enables Gradle caching (removes `cache-disabled: true`)

## Test plan
- [ ] Re-run release workflow after merge — Java cross-server tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfipXzLGKsWuyLdDjUGRYy