### PR TITLE
ci: Full test suites in release, build-only in publish

### DIFF
--- a/.github/actions/setup-go-helper/action.yml
+++ b/.github/actions/setup-go-helper/action.yml
@@ -1,0 +1,22 @@
+name: Setup Go cross-test helper
+description: Build the Go cross-test helper binary for cross-language server-to-server tests
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@v7
+      with:
+        go-version: stable
+        cache-dependency-path: cross_test/go_helper/go.sum
+
+    - name: Cache Go cross-test helper
+      uses: actions/cache@v4
+      with:
+        path: cross_test/go_helper/go_helper
+        key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
+
+    - name: Build Go cross-test helper
+      shell: bash
+      working-directory: cross_test/go_helper
+      run: go build -o go_helper .

--- a/.github/actions/test-csharp/action.yml
+++ b/.github/actions/test-csharp/action.yml
@@ -1,0 +1,22 @@
+name: Test C# SDK
+description: Build and test the C# SDK including cross-language server-to-server tests
+
+runs:
+  using: composite
+  steps:
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: "10.0.x"
+
+    - uses: ./.github/actions/setup-go-helper
+
+    - name: Build
+      shell: bash
+      working-directory: csharp
+      run: dotnet build
+
+    - name: Test
+      shell: bash
+      working-directory: csharp
+      run: dotnet test --no-build

--- a/.github/actions/test-java/action.yml
+++ b/.github/actions/test-java/action.yml
@@ -1,0 +1,23 @@
+name: Test Java SDK
+description: Build and test the Java SDK including cross-language server-to-server tests
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Java
+      uses: actions/setup-java@v6
+      with:
+        java-version: "17"
+        distribution: temurin
+
+    - uses: ./.github/actions/setup-go-helper
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
+
+    - name: Build and test
+      shell: bash
+      working-directory: java
+      run: |
+        chmod +x gradlew
+        ./gradlew build --no-daemon

--- a/.github/actions/test-node/action.yml
+++ b/.github/actions/test-node/action.yml
@@ -1,0 +1,29 @@
+name: Test Node SDK
+description: Build and test the Node.js SDK including cross-language server-to-server tests
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v7
+      with:
+        node-version: lts/*
+        cache: npm
+        cache-dependency-path: node/sdk/package-lock.json
+
+    - uses: ./.github/actions/setup-go-helper
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: node/sdk
+      run: npm ci
+
+    - name: Build
+      shell: bash
+      working-directory: node/sdk
+      run: npm run build
+
+    - name: Test
+      shell: bash
+      working-directory: node/sdk
+      run: npm test

--- a/.github/actions/test-python/action.yml
+++ b/.github/actions/test-python/action.yml
@@ -1,0 +1,35 @@
+name: Test Python SDK
+description: Build and test the Python SDK including cross-language server-to-server tests
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.13"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: python/uv.lock
+
+    - uses: ./.github/actions/setup-go-helper
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: python
+      run: uv sync --all-packages
+
+    - name: Build packages
+      shell: bash
+      working-directory: python
+      run: |
+        uv build --package t0-provider-sdk
+        uv build --package t0-provider-starter
+
+    - name: Test
+      shell: bash
+      working-directory: python
+      run: uv run pytest

--- a/.github/workflows/ci-csharp.yaml
+++ b/.github/workflows/ci-csharp.yaml
@@ -8,6 +8,8 @@ on:
       - "go/**"
       - "proto/**"
       - "cross_test/**"
+      - ".github/actions/setup-go-helper/**"
+      - ".github/actions/test-csharp/**"
       - ".github/workflows/ci-csharp.yaml"
   pull_request:
     branches: [master]
@@ -16,6 +18,8 @@ on:
       - "go/**"
       - "proto/**"
       - "cross_test/**"
+      - ".github/actions/setup-go-helper/**"
+      - ".github/actions/test-csharp/**"
       - ".github/workflows/ci-csharp.yaml"
 
 concurrency:
@@ -32,34 +36,7 @@ jobs:
         with:
           show-progress: false
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: "10.0.x"
-
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version: "stable"
-          cache-dependency-path: cross_test/go_helper/go.sum
-
-      - name: Cache Go cross-test helper
-        uses: actions/cache@v4
-        with:
-          path: cross_test/go_helper/go_helper
-          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
-
-      - name: Build Go cross-test helper
-        working-directory: cross_test/go_helper
-        run: go build -o go_helper .
-
-      - name: Build
-        working-directory: csharp
-        run: dotnet build
-
-      - name: Test
-        working-directory: csharp
-        run: dotnet test --no-build
+      - uses: ./.github/actions/test-csharp
 
       - name: Pack SDK
         working-directory: csharp/sdk/T0.ProviderSdk

--- a/.github/workflows/ci-java.yaml
+++ b/.github/workflows/ci-java.yaml
@@ -8,6 +8,8 @@ on:
       - "proto/**"
       - "cross_test/**"
       - "go/**"
+      - ".github/actions/setup-go-helper/**"
+      - ".github/actions/test-java/**"
       - ".github/workflows/ci-java.yaml"
   pull_request:
     branches: [master]
@@ -16,6 +18,8 @@ on:
       - "proto/**"
       - "cross_test/**"
       - "go/**"
+      - ".github/actions/setup-go-helper/**"
+      - ".github/actions/test-java/**"
       - ".github/workflows/ci-java.yaml"
 
 concurrency:
@@ -30,33 +34,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          java-version: "17"
-          distribution: "temurin"
-
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version: "stable"
-          cache-dependency-path: cross_test/go_helper/go.sum
-
-      - name: Cache Go cross-test helper
-        uses: actions/cache@v4
-        with:
-          path: cross_test/go_helper/go_helper
-          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
-
-      - name: Build Go cross-test helper
-        working-directory: cross_test/go_helper
-        run: go build -o go_helper .
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: Build and test
-        working-directory: java
-        run: |
-          chmod +x gradlew
-          ./gradlew build -x distTar -x distZip --no-daemon
+      - uses: ./.github/actions/test-java

--- a/.github/workflows/ci-node.yaml
+++ b/.github/workflows/ci-node.yaml
@@ -8,6 +8,8 @@ on:
       - "go/**"
       - "proto/**"
       - "cross_test/**"
+      - ".github/actions/setup-go-helper/**"
+      - ".github/actions/test-node/**"
       - ".github/workflows/ci-node.yaml"
   pull_request:
     branches: [master]
@@ -16,6 +18,8 @@ on:
       - "go/**"
       - "proto/**"
       - "cross_test/**"
+      - ".github/actions/setup-go-helper/**"
+      - ".github/actions/test-node/**"
       - ".github/workflows/ci-node.yaml"
 
 concurrency:
@@ -32,40 +36,7 @@ jobs:
         with:
           show-progress: false
 
-      - name: Setup Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: lts/*
-          cache: npm
-          cache-dependency-path: node/sdk/package-lock.json
-
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version: "stable"
-          cache-dependency-path: cross_test/go_helper/go.sum
-
-      - name: Cache Go cross-test helper
-        uses: actions/cache@v4
-        with:
-          path: cross_test/go_helper/go_helper
-          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
-
-      - name: Build Go cross-test helper
-        working-directory: cross_test/go_helper
-        run: go build -o go_helper .
-
-      - name: Install SDK dependencies
-        working-directory: node/sdk
-        run: npm ci
-
-      - name: Build SDK
-        working-directory: node/sdk
-        run: npm run build
-
-      - name: Run SDK Tests
-        working-directory: node/sdk
-        run: npm test
+      - uses: ./.github/actions/test-node
 
       # Type-check the starter template against the freshly built SDK.
       # The template has no lockfile (industry standard for scaffold

--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -8,6 +8,8 @@ on:
       - "go/**"
       - "proto/**"
       - "cross_test/**"
+      - ".github/actions/setup-go-helper/**"
+      - ".github/actions/test-python/**"
       - ".github/workflows/ci-python.yaml"
   pull_request:
     branches: [master]
@@ -16,6 +18,8 @@ on:
       - "go/**"
       - "proto/**"
       - "cross_test/**"
+      - ".github/actions/setup-go-helper/**"
+      - ".github/actions/test-python/**"
       - ".github/workflows/ci-python.yaml"
 
 concurrency:
@@ -32,42 +36,7 @@ jobs:
         with:
           show-progress: false
 
-      - name: Setup Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.13"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: python/uv.lock
-
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version: "stable"
-          cache-dependency-path: cross_test/go_helper/go.sum
-
-      - name: Cache Go cross-test helper
-        uses: actions/cache@v4
-        with:
-          path: cross_test/go_helper/go_helper
-          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
-
-      - name: Build Go cross-test helper
-        working-directory: cross_test/go_helper
-        run: go build -o go_helper .
-
-      - name: Install dependencies
-        working-directory: python
-        run: uv sync --all-packages
-
-      - name: Build packages
-        working-directory: python
-        run: |
-          uv build --package t0-provider-sdk
-          uv build --package t0-provider-starter
+      - uses: ./.github/actions/test-python
 
       - name: Lint
         working-directory: python
@@ -76,15 +45,6 @@ jobs:
       - name: Format check
         working-directory: python
         run: uv run ruff format --check .
-
-      # TODO: re-enable once type errors are fixed
-      # - name: Type check
-      #   working-directory: python
-      #   run: uv run mypy .
-
-      - name: Run tests
-        working-directory: python
-        run: uv run pytest
 
   # Customers install the SDK without our lockfile, so their resolver picks the
   # newest release of every open-ranged dependency. The job above only ever

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -75,14 +75,12 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-disabled: true
 
       - name: Build
         working-directory: java
         run: |
           chmod +x gradlew
-          ./gradlew build --no-daemon
+          ./gradlew build -x test --no-daemon
 
   build-python:
     name: Build Python
@@ -386,8 +384,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-disabled: true
 
       - name: Get version from tag
         id: version
@@ -406,7 +402,7 @@ jobs:
         working-directory: java
         run: |
           chmod +x gradlew
-          ./gradlew build --no-daemon
+          ./gradlew build -x test --no-daemon
 
       - name: Publish to Maven Central
         working-directory: java

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,22 +74,6 @@ jobs:
           java-version: "17"
           distribution: "temurin"
 
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version: "stable"
-          cache-dependency-path: cross_test/go_helper/go.sum
-
-      - name: Cache Go cross-test helper
-        uses: actions/cache@v4
-        with:
-          path: cross_test/go_helper/go_helper
-          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
-
-      - name: Build Go cross-test helper
-        working-directory: cross_test/go_helper
-        run: go build -o go_helper .
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
@@ -97,7 +81,7 @@ jobs:
         working-directory: java
         run: |
           chmod +x gradlew
-          ./gradlew build --no-daemon
+          ./gradlew build -x test --no-daemon
 
   build-python:
     name: Build Python

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           go test ./...
 
   build-node:
-    name: Build Node
+    name: Test Node
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -48,38 +48,10 @@ jobs:
         with:
           show-progress: false
 
-      - name: Setup Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: lts/*
-          cache: npm
-          cache-dependency-path: node/sdk/package-lock.json
-
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version: "stable"
-          cache-dependency-path: cross_test/go_helper/go.sum
-
-      - name: Cache Go cross-test helper
-        uses: actions/cache@v4
-        with:
-          path: cross_test/go_helper/go_helper
-          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
-
-      - name: Build Go cross-test helper
-        working-directory: cross_test/go_helper
-        run: go build -o go_helper .
-
-      - name: Build and test SDK
-        working-directory: node/sdk
-        run: |
-          npm ci
-          npm run build
-          npm test
+      - uses: ./.github/actions/test-node
 
   build-java:
-    name: Build Java
+    name: Test Java
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -87,39 +59,10 @@ jobs:
         with:
           show-progress: false
 
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          java-version: "17"
-          distribution: "temurin"
-
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version: "stable"
-          cache-dependency-path: cross_test/go_helper/go.sum
-
-      - name: Cache Go cross-test helper
-        uses: actions/cache@v4
-        with:
-          path: cross_test/go_helper/go_helper
-          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
-
-      - name: Build Go cross-test helper
-        working-directory: cross_test/go_helper
-        run: go build -o go_helper .
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: Build and test
-        working-directory: java
-        run: |
-          chmod +x gradlew
-          ./gradlew build --no-daemon
+      - uses: ./.github/actions/test-java
 
   build-python:
-    name: Build Python
+    name: Test Python
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -127,43 +70,10 @@ jobs:
         with:
           show-progress: false
 
-      - name: Setup Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.13"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: python/uv.lock
-
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version: "stable"
-          cache-dependency-path: cross_test/go_helper/go.sum
-
-      - name: Cache Go cross-test helper
-        uses: actions/cache@v4
-        with:
-          path: cross_test/go_helper/go_helper
-          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
-
-      - name: Build Go cross-test helper
-        working-directory: cross_test/go_helper
-        run: go build -o go_helper .
-
-      - name: Build and test
-        working-directory: python
-        run: |
-          uv sync --all-packages
-          uv build --package t0-provider-sdk
-          uv build --package t0-provider-starter
-          uv run pytest
+      - uses: ./.github/actions/test-python
 
   build-csharp:
-    name: Build C#
+    name: Test C#
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -171,32 +81,7 @@ jobs:
         with:
           show-progress: false
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: "10.0.x"
-
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version: "stable"
-          cache-dependency-path: cross_test/go_helper/go.sum
-
-      - name: Cache Go cross-test helper
-        uses: actions/cache@v4
-        with:
-          path: cross_test/go_helper/go_helper
-          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
-
-      - name: Build Go cross-test helper
-        working-directory: cross_test/go_helper
-        run: go build -o go_helper .
-
-      - name: Build and test
-        working-directory: csharp
-        run: |
-          dotnet build
-          dotnet test --no-build
+      - uses: ./.github/actions/test-csharp
 
   build-cli:
     name: Build CLI

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ permissions:
   contents: write
 
 jobs:
-  # --- Validate all builds before releasing ---
+  # --- Validate all builds + tests before releasing ---
   build-go:
     name: Build Go
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -33,9 +33,11 @@ jobs:
           go-version: "stable"
           cache-dependency-path: go/go.sum
 
-      - name: Build
+      - name: Build and test
         working-directory: go
-        run: go build ./...
+        run: |
+          go vet ./...
+          go test ./...
 
   build-node:
     name: Build Node
@@ -53,11 +55,28 @@ jobs:
           cache: npm
           cache-dependency-path: node/sdk/package-lock.json
 
-      - name: Build SDK
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "stable"
+          cache-dependency-path: cross_test/go_helper/go.sum
+
+      - name: Cache Go cross-test helper
+        uses: actions/cache@v4
+        with:
+          path: cross_test/go_helper/go_helper
+          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
+
+      - name: Build Go cross-test helper
+        working-directory: cross_test/go_helper
+        run: go build -o go_helper .
+
+      - name: Build and test SDK
         working-directory: node/sdk
         run: |
           npm ci
           npm run build
+          npm test
 
   build-java:
     name: Build Java
@@ -74,14 +93,30 @@ jobs:
           java-version: "17"
           distribution: "temurin"
 
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "stable"
+          cache-dependency-path: cross_test/go_helper/go.sum
+
+      - name: Cache Go cross-test helper
+        uses: actions/cache@v4
+        with:
+          path: cross_test/go_helper/go_helper
+          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
+
+      - name: Build Go cross-test helper
+        working-directory: cross_test/go_helper
+        run: go build -o go_helper .
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Build
+      - name: Build and test
         working-directory: java
         run: |
           chmod +x gradlew
-          ./gradlew build -x test --no-daemon
+          ./gradlew build --no-daemon
 
   build-python:
     name: Build Python
@@ -103,12 +138,29 @@ jobs:
           enable-cache: true
           cache-dependency-glob: python/uv.lock
 
-      - name: Build
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "stable"
+          cache-dependency-path: cross_test/go_helper/go.sum
+
+      - name: Cache Go cross-test helper
+        uses: actions/cache@v4
+        with:
+          path: cross_test/go_helper/go_helper
+          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
+
+      - name: Build Go cross-test helper
+        working-directory: cross_test/go_helper
+        run: go build -o go_helper .
+
+      - name: Build and test
         working-directory: python
         run: |
-          uv sync
+          uv sync --all-packages
           uv build --package t0-provider-sdk
           uv build --package t0-provider-starter
+          uv run pytest
 
   build-csharp:
     name: Build C#
@@ -124,9 +176,27 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Build
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "stable"
+          cache-dependency-path: cross_test/go_helper/go.sum
+
+      - name: Cache Go cross-test helper
+        uses: actions/cache@v4
+        with:
+          path: cross_test/go_helper/go_helper
+          key: go-helper-${{ runner.os }}-${{ hashFiles('cross_test/go_helper/**', 'go/**/*.go', 'go/go.sum') }}
+
+      - name: Build Go cross-test helper
+        working-directory: cross_test/go_helper
+        run: go build -o go_helper .
+
+      - name: Build and test
         working-directory: csharp
-        run: dotnet build
+        run: |
+          dotnet build
+          dotnet test --no-build
 
   build-cli:
     name: Build CLI


### PR DESCRIPTION
## Summary
- **Release workflow**: now runs full test suites (including cross-server tests with Go helper) for all 5 languages, making it a self-sufficient safety gate that prevents untested releases
- **Publish workflow**: stays build-only (`build -x test` for Java) since it runs on the exact tag commit that release already validated
- Enables Gradle caching (removes `cache-disabled: true`) in both workflows

## Design
```
CI (master push) → Release (manual) → Publish (tag push)
                    ↑ full tests here   ↑ build-only here
```

Release is the single gate: even if CI was skipped (path-filtered, cancelled), release catches it before tagging.

## Test plan
- [ ] Trigger release workflow — all 5 language jobs should run tests and pass
- [ ] Verify publish workflow's Java jobs use `build -x test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfipXzLGKsWuyLdDjUGRYy