### PR TITLE
fix(ci): Rename release jobs to Test

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   # --- Validate all builds + tests before releasing ---
   build-go:
-    name: Build Go
+    name: Test Go
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -84,7 +84,7 @@ jobs:
       - uses: ./.github/actions/test-csharp
 
   build-cli:
-    name: Build CLI
+    name: Test CLI
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Rename "Build Go" → "Test Go" and "Build CLI" → "Test CLI" in release workflow
- Aligns with the other 4 language jobs already named "Test X"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfipXzLGKsWuyLdDjUGRYy