### PR TITLE
ci: Add auto-generated release notes to GitHub Releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: CI
+      labels:
+        - github_actions
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -369,4 +369,4 @@ jobs:
           gh release create "v${{ steps.version.outputs.version }}" \
             --verify-tag \
             --title "${{ steps.version.outputs.version }}" \
-            --notes "Release ${{ steps.version.outputs.version }}"
+            --generate-notes


### PR DESCRIPTION
## Summary

- Replace hardcoded `--notes "Release X.Y.Z"` with `--generate-notes` in `release.yaml`
- Add `.github/release.yml` to categorize PRs by label: Features, Bug Fixes, Dependencies, CI, Documentation, and a catch-all Other Changes
- Uses existing repo labels (`enhancement`, `bug`, `dependencies`, `github_actions`, `documentation`)

## Test plan

- [ ] Merge this PR
- [ ] Trigger a patch release via `gh workflow run release.yaml -f bump=patch --ref master`
- [ ] Confirm the created GitHub Release has auto-generated, categorized release notes instead of bare "Release X.Y.Z"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fan4WTU1uABUiAXKtnHCjb