### PR TITLE
feat(node): harden starter Decimal and key onboarding

### DIFF
--- a/.github/workflows/ci-cli.yaml
+++ b/.github/workflows/ci-cli.yaml
@@ -7,6 +7,7 @@ on:
       - "cli/**"
       - "go/starter/template/**"
       - "node/starter/template/**"
+      - "node/sdk/**"
       - "python/starter/src/t0_provider_starter/template/**"
       - "java/starter/template/**"
       - "csharp/starter/template/**"
@@ -17,6 +18,7 @@ on:
       - "cli/**"
       - "go/starter/template/**"
       - "node/starter/template/**"
+      - "node/sdk/**"
       - "python/starter/src/t0_provider_starter/template/**"
       - "java/starter/template/**"
       - "csharp/starter/template/**"
@@ -78,6 +80,13 @@ jobs:
         working-directory: cli
         run: go test -v ./...
 
+      - name: Pack Node SDK for scaffold test
+        working-directory: node/sdk
+        run: |
+          npm ci
+          npm run build
+          npm pack
+
       # --- Scaffold all 5 ecosystems ---
       - name: Scaffold Go project
         run: |
@@ -133,21 +142,18 @@ jobs:
           # Go fetches the locally-built archive without a checksum conflict.
           sed -i '/^github.com\/t-0-network\/provider-sdk\/go /d' go.sum
           export GOMODCACHE="${RUNNER_TEMP}/template-modcache"
-          export GOPROXY="file://${PROXY_DIR},direct"
+          export GOPROXY="file://${PROXY_DIR},https://proxy.golang.org,direct"
           export GONOSUMDB="github.com/t-0-network"
           go mod tidy
           go build ./...
 
-      # Registry-dependent verify steps run only on PRs.  On push-to-master the
-      # PR already validated them, and on release commits the new SDK version is
-      # not yet published (the publish workflow runs in parallel), so they would
-      # fail with "package not found".  Go is immune (local file:// proxy above).
-      - name: Verify Node scaffold compiles
-        if: github.event_name == 'pull_request'
+      # Use the locally packed SDK so this also validates release commits before
+      # the package is available from npm, without rewriting the template manifest or lockfile.
+      - name: Verify Node scaffold builds and tests
         working-directory: test-node
         run: |
-          npm install --silent
-          npm run build
+          npm install --silent --no-save --package-lock=false --no-audit --no-fund ../node/sdk/t-0-provider-sdk-*.tgz
+          npm test
 
       - name: Verify Python scaffold resolves deps
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -71,7 +71,7 @@ jobs:
           # Go fetches the locally-built archive without a checksum conflict.
           sed -i '/^github.com\/t-0-network\/provider-sdk\/go /d' go.sum
           export GOMODCACHE="${RUNNER_TEMP}/template-modcache"
-          export GOPROXY="file://${PROXY_DIR},direct"
+          export GOPROXY="file://${PROXY_DIR},https://proxy.golang.org,direct"
           export GONOSUMDB="github.com/t-0-network"
           go mod tidy
           go build ./...

--- a/.github/workflows/ci-node.yaml
+++ b/.github/workflows/ci-node.yaml
@@ -38,21 +38,22 @@ jobs:
 
       - uses: ./.github/actions/test-node
 
-      # Type-check the starter template against the freshly built SDK.
+      # Test the starter template against the freshly built SDK.
       # The template has no lockfile (industry standard for scaffold
       # tools — create.ts regenerates one via `npm install` at scaffold
       # time). We pack the local SDK and install it directly so the
-      # template always type-checks against unreleased SDK changes, and
-      # CI works even on release commits where the new version isn't
-      # published to npm yet.
-      - name: Pack SDK for template type-check
+      # template always tests against unreleased SDK changes, and CI
+      # works even on release commits where the new version isn't
+      # published to npm yet. --no-save and --package-lock=false keep test-only
+      # file paths out of the release-managed manifest and template.
+      - name: Pack SDK for template test
         working-directory: node/sdk
         run: npm pack
 
       - name: Install template deps with local SDK
         working-directory: node/starter/template
-        run: npm install --no-audit --no-fund ../../sdk/t-0-provider-sdk-*.tgz
+        run: npm install --no-save --package-lock=false --no-audit --no-fund ../../sdk/t-0-provider-sdk-*.tgz
 
-      - name: Type-check starter template against local SDK
+      - name: Test starter template against local SDK
         working-directory: node/starter/template
-        run: npx tsc --noEmit -p tsconfig.json
+        run: npm test

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -205,7 +205,7 @@ jobs:
           PROXY_DIR="${RUNNER_TEMP}/goproxy"
           GOPROXY=direct go -C .github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "v${VERSION}" "${PROXY_DIR}"
           cd go/starter/template
-          GOPROXY="file://${PROXY_DIR},direct" GONOSUMDB="github.com/t-0-network" go build -mod=readonly ./...
+          GOPROXY="file://${PROXY_DIR},https://proxy.golang.org,direct" GONOSUMDB="github.com/t-0-network" go build -mod=readonly ./...
 
   publish-node-sdk:
     name: Publish Node SDK

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -232,7 +232,7 @@ jobs:
           GOPROXY=direct go -C .github/tools/sumtool run . "${GITHUB_WORKSPACE}/go" "v${VERSION}" "${PROXY_DIR}"
           cd go/starter/template
           go mod edit -require "github.com/t-0-network/provider-sdk/go@v${VERSION}"
-          export GOPROXY="file://${PROXY_DIR},direct"
+          export GOPROXY="file://${PROXY_DIR},https://proxy.golang.org,direct"
           export GONOSUMDB="github.com/t-0-network"
           go mod tidy
           go build ./...

--- a/node/sdk/README.md
+++ b/node/sdk/README.md
@@ -148,8 +148,21 @@ For custom proto registries (e.g. non-network schemas with custom predefined rul
 <details>
 <summary>Lower-level primitives</summary>
 
-The individual building blocks are also exported: `createRequestVerifier`, `rejectRequest`, `verifySignature`, `computeDigest`, `keccak256`, `parsePublicKey`, `publicKeysEqual`, and the `NetworkHeaders` header-name enum. You can import just the crypto module via the `./crypto` subpath: `import { createRequestVerifier } from "@t-0/provider-sdk/crypto"`.
+The individual building blocks are also exported: `createRequestVerifier`, `rejectRequest`, `verifySignature`, `computeDigest`, `keccak256`, `parsePublicKey`, `publicKeyFromPrivateKey`, `publicKeysEqual`, and the `NetworkHeaders` header-name enum. You can import just the crypto module via the `./crypto` subpath: `import { createRequestVerifier } from "@t-0/provider-sdk/crypto"`.
 </details>
+
+### Provider Public Key
+
+Derive the uncompressed public key to register with the T-0 team from the same private key used by your client:
+
+```ts
+import { publicKeyFromPrivateKey } from "@t-0/provider-sdk";
+
+const publicKey = publicKeyFromPrivateKey(process.env.PROVIDER_PRIVATE_KEY!);
+console.log(publicKey); // 0x04-prefixed uncompressed public key
+```
+
+The input may be bare hexadecimal or use the lowercase `0x` prefix; output is canonical lowercase `0x04...`.
 
 ### Network Client
 

--- a/node/sdk/package.json
+++ b/node/sdk/package.json
@@ -61,6 +61,6 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:post": "echo '{\"type\":\"commonjs\"}' > lib/cjs/package.json",
     "release": "npm run buf:generate && npm run build && npm publish --access public",
-    "test": "node --import tsx --test test/**/*.test.ts"
+    "test": "npm run build && node --import tsx --test test/**/*.test.ts"
   }
 }

--- a/node/sdk/src/common/client/signer.ts
+++ b/node/sdk/src/common/client/signer.ts
@@ -1,5 +1,6 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js'
 import type {Signature} from "./client.js";
+import { parsePrivateKey } from "../crypto/keys.js";
 
 export const CreateSigner = (privateKey: string | Buffer)=> {
     privateKey = parsePrivateKey(privateKey)
@@ -19,24 +20,6 @@ export const CreateSigner = (privateKey: string | Buffer)=> {
             publicKey: publicKey,
         };
     }
-}
-
-const parsePrivateKey = (privateKey: string | Buffer) => {
-    if (typeof privateKey == 'string'){
-        privateKey = privateKey.replace(/^0x/, '');
-        if (!/^[0-9a-fA-F]{64}$/.test(privateKey)) {
-            throw new Error('Private key must be 64 hex characters');
-        }
-
-        privateKey = Buffer.from(privateKey, 'hex');
-    }
-
-    // Validate private key
-    if (!secp256k1.utils.isValidSecretKey(privateKey)) {
-        throw new Error('Invalid private key');
-    }
-
-    return privateKey
 }
 
 export default CreateSigner;

--- a/node/sdk/src/common/client/signer.ts
+++ b/node/sdk/src/common/client/signer.ts
@@ -1,10 +1,10 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js'
 import type {Signature} from "./client.js";
-import { parsePrivateKey } from "../crypto/keys.js";
+import { parsePrivateKey, uncompressedPublicKeyFromPrivateKey } from "../crypto/keys.js";
 
 export const CreateSigner = (privateKey: string | Buffer)=> {
     privateKey = parsePrivateKey(privateKey)
-    const publicKey = Buffer.from(secp256k1.getPublicKey(privateKey, false));
+    const publicKey = uncompressedPublicKeyFromPrivateKey(privateKey);
 
     return async (data: Buffer): Promise<Signature> => {
         // Ensure hash is 32 bytes

--- a/node/sdk/src/common/crypto/index.ts
+++ b/node/sdk/src/common/crypto/index.ts
@@ -1,6 +1,6 @@
 export { verifySignature } from './verify.js'
 export { keccak256, computeDigest } from './hash.js'
-export { parsePublicKey, publicKeysEqual } from './keys.js'
+export { parsePublicKey, publicKeyFromPrivateKey, publicKeysEqual } from './keys.js'
 export { createRequestVerifier, DEFAULT_TOLERANCE_MS, rejectRequest } from './request.js'
 export type { CreateVerifierOptions, VerifyRequest, VerifyRequestResult, VerifyRequestFailure, RequestVerifier, RejectedRequest } from './request.js'
 export type { CreateDecoderOptions, IncomingHeaders, IncomingRequest, WireFormat, DecodeRequestFailure, Violation, WireResponse, DecodeError, DecodeRequestResult, RequestDecoder } from './decode.js'

--- a/node/sdk/src/common/crypto/keys.ts
+++ b/node/sdk/src/common/crypto/keys.ts
@@ -1,3 +1,27 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+
+export function parsePrivateKey(privateKey: string | Buffer): Buffer {
+  if (typeof privateKey === 'string') {
+    privateKey = privateKey.replace(/^0x/, '');
+    if (!/^[0-9a-fA-F]{64}$/.test(privateKey)) {
+      throw new Error('Private key must be 64 hex characters');
+    }
+
+    privateKey = Buffer.from(privateKey, 'hex');
+  }
+
+  if (!secp256k1.utils.isValidSecretKey(privateKey)) {
+    throw new Error('Invalid private key');
+  }
+
+  return privateKey;
+}
+
+export function publicKeyFromPrivateKey(hex: string): string {
+  const publicKey = secp256k1.getPublicKey(parsePrivateKey(hex), false);
+  return `0x${Buffer.from(publicKey).toString('hex')}`;
+}
+
 export function parsePublicKey(key: string | Buffer): Buffer {
   if (typeof key === 'string') {
     const hex = key.startsWith('0x') ? key.slice(2) : key;

--- a/node/sdk/src/common/crypto/keys.ts
+++ b/node/sdk/src/common/crypto/keys.ts
@@ -17,9 +17,12 @@ export function parsePrivateKey(privateKey: string | Buffer): Buffer {
   return privateKey;
 }
 
+export function uncompressedPublicKeyFromPrivateKey(privateKey: Buffer): Buffer {
+  return Buffer.from(secp256k1.getPublicKey(privateKey, false));
+}
+
 export function publicKeyFromPrivateKey(hex: string): string {
-  const publicKey = secp256k1.getPublicKey(parsePrivateKey(hex), false);
-  return `0x${Buffer.from(publicKey).toString('hex')}`;
+  return `0x${uncompressedPublicKeyFromPrivateKey(parsePrivateKey(hex)).toString('hex')}`;
 }
 
 export function parsePublicKey(key: string | Buffer): Buffer {

--- a/node/sdk/src/index.ts
+++ b/node/sdk/src/index.ts
@@ -1,4 +1,4 @@
-export { verifySignature, keccak256, computeDigest, parsePublicKey, publicKeysEqual, createRequestVerifier, createRequestDecoder, DEFAULT_TOLERANCE_MS, rejectRequest } from "./crypto/index.js"
+export { verifySignature, keccak256, computeDigest, parsePublicKey, publicKeyFromPrivateKey, publicKeysEqual, createRequestVerifier, createRequestDecoder, DEFAULT_TOLERANCE_MS, rejectRequest } from "./crypto/index.js"
 export type { CreateVerifierOptions, VerifyRequest, VerifyRequestResult, VerifyRequestFailure, RequestVerifier, RejectedRequest, CreateDecoderOptions, IncomingHeaders, IncomingRequest, WireFormat, DecodeRequestFailure, Violation, WireResponse, DecodeError, DecodeRequestResult, RequestDecoder } from "./crypto/index.js"
 export * from "./client/client.js"
 export * from "./service/service.js"

--- a/node/sdk/test/crypto.test.ts
+++ b/node/sdk/test/crypto.test.ts
@@ -3,7 +3,8 @@ import * as nodeAssert from 'node:assert/strict';
 import { keccak_256 } from '@noble/hashes/sha3.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { CreateSigner } from '../src/client/signer.js';
-import { verifySignature, keccak256, computeDigest, parsePublicKey, publicKeysEqual, createRequestVerifier, DEFAULT_TOLERANCE_MS, NetworkHeaders } from '../src/crypto/index.js';
+import { verifySignature, keccak256, computeDigest, parsePublicKey, publicKeyFromPrivateKey, publicKeysEqual, createRequestVerifier, DEFAULT_TOLERANCE_MS, NetworkHeaders } from '../src/crypto/index.js';
+import * as sdk from '../src/index.js';
 import type { VerifyRequest } from '../src/crypto/index.js';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -456,6 +457,65 @@ describe('crypto/verifySignature', () => {
   });
 });
 
+describe('crypto/publicKeyFromPrivateKey', () => {
+  const secp256k1Order = 'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141';
+  const maxSecret = 'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140';
+
+  for (const [name, key] of Object.entries({
+    primary: vectors.keys,
+    impostor: vectors.impostor_keys,
+  })) {
+    it(`derives the ${name} public key from the cross-language vector`, () => {
+      const publicKey = publicKeyFromPrivateKey(key.private_key);
+      nodeAssert.equal(publicKey, `0x${key.public_key}`);
+      nodeAssert.match(publicKey, /^0x04[0-9a-f]{128}$/);
+    });
+  }
+
+  it('accepts a lowercase 0x-prefixed private key', () => {
+    nodeAssert.equal(
+      publicKeyFromPrivateKey(`0x${vectors.keys.private_key}`),
+      `0x${vectors.keys.public_key}`,
+    );
+  });
+
+  it('accepts the minimum and maximum valid secp256k1 secrets', () => {
+    for (const secret of ['0'.repeat(63) + '1', maxSecret]) {
+      nodeAssert.match(publicKeyFromPrivateKey(secret), /^0x04[0-9a-f]{128}$/);
+    }
+  });
+
+  it('rejects an uppercase 0X private-key prefix', () => {
+    nodeAssert.throws(() => publicKeyFromPrivateKey(`0X${vectors.keys.private_key}`));
+  });
+
+  it('rejects malformed, wrong-length, zero, and out-of-range secrets', () => {
+    for (const secret of [
+      '',
+      'not-a-valid-key',
+      '0'.repeat(63),
+      '0'.repeat(64),
+      secp256k1Order,
+      `0x${secp256k1Order}`,
+    ]) {
+      nodeAssert.throws(() => publicKeyFromPrivateKey(secret));
+    }
+  });
+
+  it('preserves synchronous signer validation for string and Buffer inputs', async () => {
+    nodeAssert.throws(() => CreateSigner('0'.repeat(64)), {message: 'Invalid private key'});
+    nodeAssert.throws(() => CreateSigner(Buffer.alloc(32)), {message: 'Invalid private key'});
+
+    const signer = CreateSigner(Buffer.from(vectors.keys.private_key, 'hex'));
+    const signature = await signer(Buffer.alloc(32, 0x01));
+    nodeAssert.equal(signature.publicKey.toString('hex'), vectors.keys.public_key);
+  });
+
+  it('is exported from the crypto and root source entry points', () => {
+    nodeAssert.strictEqual(sdk.publicKeyFromPrivateKey, publicKeyFromPrivateKey);
+  });
+});
+
 describe('crypto/parsePublicKey', () => {
   const hexKey = vectors.keys.public_key;
 
@@ -467,6 +527,10 @@ describe('crypto/parsePublicKey', () => {
   it('parses 0x-prefixed hex string', () => {
     const key = parsePublicKey('0x' + hexKey);
     nodeAssert.equal(key.toString('hex'), hexKey);
+  });
+
+  it('rejects an uppercase 0X public-key prefix', () => {
+    nodeAssert.throws(() => parsePublicKey('0X' + hexKey));
   });
 
   it('parses Buffer', () => {

--- a/node/sdk/test/package_exports.test.ts
+++ b/node/sdk/test/package_exports.test.ts
@@ -1,0 +1,19 @@
+import { strict as assert } from 'node:assert';
+import { createRequire } from 'node:module';
+import { test } from 'node:test';
+
+const privateKey = '0000000000000000000000000000000000000000000000000000000000000001';
+const publicKey = '0x0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8';
+
+test('root and crypto package exports work from ESM and CommonJS builds', async () => {
+  const esmRoot = await import('@t-0/provider-sdk');
+  const esmCrypto = await import('@t-0/provider-sdk/crypto');
+  const require = createRequire(import.meta.url);
+  const cjsRoot = require('@t-0/provider-sdk');
+  const cjsCrypto = require('@t-0/provider-sdk/crypto');
+
+  for (const entrypoint of [esmRoot, esmCrypto, cjsRoot, cjsCrypto]) {
+    assert.equal(typeof entrypoint.publicKeyFromPrivateKey, 'function');
+    assert.equal(entrypoint.publicKeyFromPrivateKey(privateKey), publicKey);
+  }
+});

--- a/node/starter/README.md
+++ b/node/starter/README.md
@@ -58,7 +58,7 @@ your-project-name/
 
 ### Phase 1: Quoting
 
-1. Open `.env` and find your generated public key (marked as "Step 1.2"). Share it with the T-0 team to register your provider.
+1. Copy the generated public key from the comment in `.env` and share it with the T-0 team to register your provider.
 2. Implement your quote publishing logic in `src/publish_quotes.ts`.
 3. Start the dev server (`npm run dev`) and verify quotes are published.
 4. Confirm quote retrieval works by checking the output of `getQuote` in `src/index.ts`.

--- a/node/starter/template/package.json
+++ b/node/starter/template/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "ts-node src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "npm run build && node --test dist/lib.test.js"
   },
   "keywords": [],
   "author": "",

--- a/node/starter/template/src/complete_manual_aml_check.ts
+++ b/node/starter/template/src/complete_manual_aml_check.ts
@@ -1,4 +1,5 @@
 import {type Client, NetworkService} from "@t-0/provider-sdk";
+import {decimalToString} from "./lib";
 
 export default async function completeManualAmlCheck(
     networkClient: Client<typeof NetworkService>,
@@ -19,7 +20,9 @@ export default async function completeManualAmlCheck(
       const approved = response.result.value;
       // Pay-in provider approved the updated quotes — proceed with the payout using
       // the updated amounts, then report the outcome via finalizePayout.
-      console.log(`Manual AML check approved for payment ${paymentId}: quoteId=${approved.payOutQuoteId}, clientQuoteId=${approved.payOutClientQuoteId}`, 'payOutAmount=', approved.payOutAmount, 'settlementAmount=', approved.settlementAmount)
+      const payOutAmount = approved.payOutAmount === undefined ? "not provided" : decimalToString(approved.payOutAmount);
+      const settlementAmount = approved.settlementAmount === undefined ? "not provided" : decimalToString(approved.settlementAmount);
+      console.log(`Manual AML check approved for payment ${paymentId}: quoteId=${approved.payOutQuoteId}, clientQuoteId=${approved.payOutClientQuoteId}, payOutAmount=${payOutAmount}, settlementAmount=${settlementAmount}`)
       break;
     }
     case 'rejected':

--- a/node/starter/template/src/create_payment_intent.ts
+++ b/node/starter/template/src/create_payment_intent.ts
@@ -1,5 +1,5 @@
 import {type Client, PaymentIntentNetwork} from "@t-0/provider-sdk";
-import {toProtoDecimal} from "./lib";
+import {decimalFromString} from "./lib";
 import {randomUUID} from "node:crypto";
 
 export default async function createPaymentIntent(
@@ -12,7 +12,7 @@ export default async function createPaymentIntent(
   const response = await paymentIntentClient.createPaymentIntent({
     externalReference: randomUUID(), // idempotency key — reuse to retry without duplicating the intent
     currency: 'EUR',
-    amount: toProtoDecimal(500, 0), // end-user pays 500 EUR
+    amount: decimalFromString("500"), // end-user pays 500 EUR
     travelRuleData: {
       // TODO: populate real IVMS101 beneficiary information for your end-user.
       beneficiary: [{}],

--- a/node/starter/template/src/get_payment_intent_quote.ts
+++ b/node/starter/template/src/get_payment_intent_quote.ts
@@ -1,5 +1,5 @@
 import {type Client, PaymentIntentNetwork} from "@t-0/provider-sdk";
-import {toProtoDecimal} from "./lib";
+import {decimalFromString} from "./lib";
 
 export default async function getPaymentIntentQuote(
     paymentIntentClient: Client<typeof PaymentIntentNetwork.PaymentIntentService>,
@@ -9,7 +9,7 @@ export default async function getPaymentIntentQuote(
   // settlement rate is determined when the pay-in provider confirms funds received.
   const response = await paymentIntentClient.getQuote({
     currency: "EUR",
-    amount: toProtoDecimal(500, 0), // end-user pays 500 EUR
+    amount: decimalFromString("500"), // end-user pays 500 EUR
   })
 
   switch (response.result.case) {

--- a/node/starter/template/src/get_quote.ts
+++ b/node/starter/template/src/get_quote.ts
@@ -1,5 +1,5 @@
 import {type Client, NetworkService, PaymentMethodType, QuoteType} from "@t-0/provider-sdk";
-import {fromProtoDecimal, toProtoDecimal} from "./lib";
+import {decimalFromString, decimalToString} from "./lib";
 
 export default async function getQuote(networkClient: Client<typeof NetworkService>) {
   const usdgbp = await networkClient.getQuote({
@@ -9,14 +9,14 @@ export default async function getQuote(networkClient: Client<typeof NetworkServi
     amount: {
       amount: {
         case: 'payOutAmount',
-        value: toProtoDecimal(50, 0)
+        value: decimalFromString("50")
       },
     }
   })
 
   switch (usdgbp.result.case) {
     case 'success':
-      console.log(`USD/GBP: ${fromProtoDecimal(usdgbp.result.value.rate!)}`)
+      console.log(`USD/GBP: ${decimalToString(usdgbp.result.value.rate!)}`)
       break;
     case 'failure':
       console.error(usdgbp.result.value.reason)

--- a/node/starter/template/src/index.ts
+++ b/node/starter/template/src/index.ts
@@ -8,6 +8,7 @@ import {
   PaymentIntentNetwork,
   PaymentIntentPayInProvider,
   ProviderService,
+  publicKeyFromPrivateKey,
   signatureValidation,
 } from "@t-0/provider-sdk";
 import invariant from 'tiny-invariant';
@@ -39,9 +40,12 @@ invariant(quotePublishingInterval > 0, 'Interval must be positive');
 invariant(networkPublicKeyHex, 'Network public key is not set');
 
 async function main() {
+  const providerPublicKey = publicKeyFromPrivateKey(privateKeyHex!);
+
   console.log('🚀 Service starting...');
   console.log(`📡 Port: ${port}`);
-  console.log(`🔑 Network Public Key: ${networkPublicKeyHex}`);
+  console.log(`🔑 Provider Public Key: ${providerPublicKey}`);
+  console.log(`🔑 T-0 Network Verification Key: ${networkPublicKeyHex}`);
   const networkClient = createClient(privateKeyHex!, endpoint, NetworkService);
   const paymentIntentClient = createClient(privateKeyHex!, endpoint, PaymentIntentNetwork.PaymentIntentService);
 
@@ -72,7 +76,7 @@ async function main() {
 
   // Step 1.1 is done. You successfully initialised starter template
 
-  // TODO: Step 1.2 take you generated public key from .env and share it with t-0 team
+  // TODO: Step 1.2 share the generated public key in the .env comment with the T-0 team
 
   // TODO: Step 1.3 implement publishing of quotes in the ./publish_quotes.ts
 

--- a/node/starter/template/src/lib.test.ts
+++ b/node/starter/template/src/lib.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {create} from "@bufbuild/protobuf";
+import {Decimal, DecimalSchema} from "@t-0/provider-sdk";
+import {decimalFromString, decimalToString} from "./lib";
+
+const MIN_INT64 = -(1n << 63n);
+const MAX_INT64 = (1n << 63n) - 1n;
+const decimal = (unscaled: bigint, exponent: number): Decimal =>
+  create(DecimalSchema, {unscaled, exponent});
+
+test("decimal helpers preserve signed-int64 boundaries exactly", () => {
+  for (const [text, unscaled] of [
+    ["9223372036854775807", MAX_INT64],
+    ["-9223372036854775808", MIN_INT64],
+    ["9007199254740993", 9007199254740993n],
+  ] as const) {
+    const value = decimalFromString(text);
+    assert.equal(value.unscaled, unscaled);
+    assert.equal(value.exponent, 0);
+    assert.equal(decimalToString(value), text);
+  }
+});
+
+test("decimal helpers format exponent bounds and point padding exactly", () => {
+  assert.deepEqual(decimalFromString("0.00000001"), decimal(1n, -8));
+  assert.equal(decimalToString(decimal(1n, -8)), "0.00000001");
+  assert.equal(decimalToString(decimal(-12n, -4)), "-0.0012");
+  assert.equal(decimalToString(decimal(123n, 0)), "123");
+  assert.equal(decimalToString(decimal(123n, 8)), "12300000000");
+});
+
+test("decimalFromString uses positive exponents only when required for int64", () => {
+  const onceShifted = decimalFromString("92233720368547758070");
+  assert.deepEqual(onceShifted, decimal(MAX_INT64, 1));
+  assert.equal(decimalToString(onceShifted), "92233720368547758070");
+
+  const fullyShifted = decimalFromString("922337203685477580700000000");
+  assert.deepEqual(fullyShifted, decimal(MAX_INT64, 8));
+  assert.equal(decimalToString(fullyShifted), "922337203685477580700000000");
+});
+
+test("decimalFromString removes trailing zeros only when representability requires it", () => {
+  const fractional = decimalFromString("1.230000000");
+  assert.deepEqual(fractional, decimal(123000000n, -8));
+  assert.equal(decimalToString(fractional), "1.23000000");
+
+  const integral = decimalFromString("100.00");
+  assert.deepEqual(integral, decimal(10000n, -2));
+  assert.equal(decimalToString(integral), "100.00");
+});
+
+test("decimal helpers normalize signed zero without losing representable scale", () => {
+  assert.deepEqual(decimalFromString("-0.00"), decimal(0n, -2));
+  assert.equal(decimalToString(decimalFromString("-0.00")), "0.00");
+  assert.equal(decimalToString(decimal(0n, 8)), "0");
+});
+
+test("decimal helpers round trip exact representable values", () => {
+  for (const value of [
+    "0",
+    "1",
+    "-1",
+    "123.4500",
+    "0.00000001",
+    "9223372036854775807",
+    "-9223372036854775808",
+    "92233720368547758070",
+  ]) {
+    assert.equal(decimalToString(decimalFromString(value)), value);
+  }
+});
+
+test("decimalFromString rejects malformed, scientific, and unrepresentable values", () => {
+  for (const value of [
+    "",
+    "+1",
+    ".1",
+    "1.",
+    " 1",
+    "1 ",
+    "1e3",
+    "1E3",
+    "1_000",
+    "0.000000001",
+    "9223372036854775808",
+    "9223372036854775807000000000",
+  ]) {
+    assert.throws(() => decimalFromString(value));
+  }
+});
+
+test("decimalToString validates incoming Decimal values", () => {
+  for (const value of [
+    decimal(MAX_INT64 + 1n, 0),
+    decimal(MIN_INT64 - 1n, 0),
+    decimal(1n, -9),
+    decimal(1n, 9),
+    {unscaled: 1n, exponent: 1.5} as Decimal,
+    {unscaled: "1", exponent: 0} as unknown as Decimal,
+  ]) {
+    assert.throws(() => decimalToString(value));
+  }
+});

--- a/node/starter/template/src/lib.ts
+++ b/node/starter/template/src/lib.ts
@@ -1,13 +1,75 @@
 import {Decimal, DecimalSchema} from "@t-0/provider-sdk";
 import {create} from "@bufbuild/protobuf";
 
-export const toProtoDecimal = (unscaled: number, exponent: number): Decimal => {
-  return create(DecimalSchema, {
-    unscaled: BigInt(unscaled),
-    exponent: exponent,
-  });
-}
+const MIN_UNSCALED = -(1n << 63n);
+const MAX_UNSCALED = (1n << 63n) - 1n;
+const MIN_EXPONENT = -8;
+const MAX_EXPONENT = 8;
 
-export const fromProtoDecimal = (value: Decimal): number => {
-  return Number(value.unscaled) * Math.pow(10, value.exponent)
-}
+const fitsInt64 = (value: bigint): boolean =>
+  value >= MIN_UNSCALED && value <= MAX_UNSCALED;
+
+export const decimalFromString = (value: string): Decimal => {
+  const match = /^(-?)(\d+)(?:\.(\d+))?$/.exec(value);
+  if (match === null) {
+    throw new Error("Decimal must use plain decimal syntax");
+  }
+
+  const [, sign, whole, fraction = ""] = match;
+  let unscaled = BigInt(`${sign}${whole}${fraction}`);
+  let exponent = fraction.length === 0 ? 0 : -fraction.length;
+
+  // Preserve a caller's scale unless it cannot be encoded by the wire contract.
+  while (exponent < MIN_EXPONENT && unscaled % 10n === 0n) {
+    unscaled /= 10n;
+    exponent += 1;
+  }
+  if (exponent < MIN_EXPONENT) {
+    throw new Error("Decimal requires more than 8 fractional digits");
+  }
+
+  // Positive exponents are necessary for exact values whose unscaled form would
+  // otherwise exceed int64. Only remove zeros when that representation is needed.
+  while (!fitsInt64(unscaled) && exponent < MAX_EXPONENT && unscaled % 10n === 0n) {
+    unscaled /= 10n;
+    exponent += 1;
+  }
+  if (!fitsInt64(unscaled)) {
+    throw new Error("Decimal unscaled value must fit signed int64");
+  }
+
+  return create(DecimalSchema, {unscaled, exponent});
+};
+
+const validateDecimal = (value: Decimal): void => {
+  if (typeof value?.unscaled !== "bigint") {
+    throw new Error("Decimal unscaled value must be a bigint");
+  }
+  if (!fitsInt64(value.unscaled)) {
+    throw new Error("Decimal unscaled value must fit signed int64");
+  }
+  if (!Number.isInteger(value.exponent) || value.exponent < MIN_EXPONENT || value.exponent > MAX_EXPONENT) {
+    throw new Error("Decimal exponent must be an integer between -8 and 8");
+  }
+};
+
+export const decimalToString = (value: Decimal): string => {
+  validateDecimal(value);
+
+  const sign = value.unscaled < 0n ? "-" : "";
+  const digits = (value.unscaled < 0n ? -value.unscaled : value.unscaled).toString();
+
+  if (value.unscaled === 0n && value.exponent >= 0) {
+    return "0";
+  }
+  if (value.exponent >= 0) {
+    return `${sign}${digits}${"0".repeat(value.exponent)}`;
+  }
+
+  const decimalPoint = digits.length + value.exponent;
+  if (decimalPoint > 0) {
+    return `${sign}${digits.slice(0, decimalPoint)}.${digits.slice(decimalPoint)}`;
+  }
+
+  return `${sign}0.${"0".repeat(-decimalPoint)}${digits}`;
+};

--- a/node/starter/template/src/payment_intent_beneficiary_service.ts
+++ b/node/starter/template/src/payment_intent_beneficiary_service.ts
@@ -2,6 +2,7 @@ import {
     HandlerContext,
     PaymentIntentBeneficiary,
 } from "@t-0/provider-sdk";
+import {decimalToString} from "./lib";
 
 /*
   Payment Intent Flow — Beneficiary Provider role.
@@ -19,14 +20,16 @@ const CreateBeneficiaryService = () => {
         // internal state accordingly.
         async paymentIntentUpdate(req: PaymentIntentBeneficiary.PaymentIntentUpdateRequest, _: HandlerContext) {
             switch (req.update.case) {
-                case 'fundsReceived':
+                case 'fundsReceived': {
+                    const settlementAmount = req.update.value.settlementAmount;
                     console.log(
                         `Payment intent ${req.paymentIntentId}: funds received,`,
-                        `settlementAmount=${JSON.stringify(req.update.value.settlementAmount)},`,
+                        `settlementAmount=${settlementAmount === undefined ? "not provided" : decimalToString(settlementAmount)},`,
                         `paymentMethod=${req.update.value.paymentMethod},`,
                         `transactionReference=${req.update.value.transactionReference}`,
                     )
                     break;
+                }
                 default:
                     console.log(`Payment intent ${req.paymentIntentId}: unknown update variant`)
             }

--- a/node/starter/template/src/publish_payment_intent_quotes.ts
+++ b/node/starter/template/src/publish_payment_intent_quotes.ts
@@ -1,5 +1,5 @@
 import {type Client, PaymentIntentNetwork, PaymentMethodType} from "@t-0/provider-sdk";
-import {toProtoDecimal} from "./lib";
+import {decimalFromString} from "./lib";
 import {randomUUID} from "node:crypto";
 import {timestampFromDate} from "@bufbuild/protobuf/wkt";
 
@@ -9,6 +9,8 @@ export default async function publishPaymentIntentQuotes(
 ): Promise<void> {
   // TODO: Step 3A.1 replace this with fetching pay-in quotes from your systems and publishing them into t-0 Network.
   // We recommend publishing at least once per 5 seconds, but not more than once per second.
+  const sampleMaxAmount = decimalFromString("1000");
+  const sampleRate = decimalFromString("0.92");
   const tick = async () => {
     try {
       // NOTE: Every updateQuote request discards all previous payment intent quotes
@@ -21,9 +23,9 @@ export default async function publishPaymentIntentQuotes(
           timestamp: timestampFromDate(new Date()),
           bands: [{
             clientQuoteId: randomUUID(),
-            maxAmount: toProtoDecimal(1000, 0), // max 1000 USD for this band
+            maxAmount: sampleMaxAmount, // max 1000 USD for this band
             // rate is always USD/XXX, so for EUR quote should be USD/EUR
-            rate: toProtoDecimal(92, -2), // rate 0.92
+            rate: sampleRate, // rate 0.92
           }],
         }],
       })

--- a/node/starter/template/src/publish_quotes.ts
+++ b/node/starter/template/src/publish_quotes.ts
@@ -1,10 +1,12 @@
 import {type Client, NetworkService, PaymentMethodType, QuoteType} from "@t-0/provider-sdk";
-import {toProtoDecimal} from "./lib";
+import {decimalFromString} from "./lib";
 import {randomUUID} from "node:crypto";
 import {timestampFromDate} from "@bufbuild/protobuf/wkt";
 
 export default async function publishQuotes(networkClient: Client<typeof NetworkService>, quotePublishingInterval: number): Promise<void> {
   // TODO: Step 1.3 replace this with receiving quotes from you systems and publishing them into t-0 Network. We recommend publishing at least once per 5 seconds, but not more than once per second
+  const sampleRate = decimalFromString("0.873");
+  const sampleMaxAmount = decimalFromString("25000");
   const tick =  async () => {
     try {
       //NOTE: Every update quote request discard all previous quotes that were published before.
@@ -14,11 +16,11 @@ export default async function publishQuotes(networkClient: Client<typeof Network
         payOut: [{
           bands: [{
             // note that rate is always USD/XXX, os that for EUR quote should be USD/EUR
-            rate: toProtoDecimal(873, -3), // rate 0.873
-            maxAmount: toProtoDecimal(25000, 0), // maximum amount in USD, could be 1000,5000,10000 or 25000
+            rate: sampleRate, // rate 0.873
+            maxAmount: sampleMaxAmount, // maximum amount in USD, could be 1000,5000,10000 or 25000
             clientQuoteId: randomUUID(),
             // optional: set fix to charge a fixed fee per transfer (e.g. wire fees)
-            // fix: toProtoDecimal(5, 0), // $5 fixed charge
+            // fix: decimalFromString("5"), // $5 fixed charge
           }],
           currency: 'EUR',
           expiration: timestampFromDate(new Date(Date.now() + 30 * 1000)), // expiration time (30 seconds from now)

--- a/node/starter/template/src/submit_payment.ts
+++ b/node/starter/template/src/submit_payment.ts
@@ -1,5 +1,5 @@
 import {type Client, NetworkService, PaymentMethodType} from "@t-0/provider-sdk";
-import {decimalFromString} from "./lib";
+import {decimalFromString, decimalToString} from "./lib";
 import {randomUUID} from "node:crypto";
 
 export default async function submitPayment(networkClient: Client<typeof NetworkService>): Promise<void> {
@@ -26,9 +26,13 @@ export default async function submitPayment(networkClient: Client<typeof Network
   })
 
   switch (result.result.case) {
-      case 'accepted':
-        console.log(`Payment accepted, ${result.result.value.settlementAmount} USD to settle`)
+      case 'accepted': {
+        const settlementAmount = result.result.value.settlementAmount === undefined
+          ? "not provided"
+          : decimalToString(result.result.value.settlementAmount);
+        console.log(`Payment accepted, ${settlementAmount} USD to settle`)
         break;
+      }
       case 'failure':
         console.log(`Payment failed with '${result.result.value.reason}'`)
         break;

--- a/node/starter/template/src/submit_payment.ts
+++ b/node/starter/template/src/submit_payment.ts
@@ -1,5 +1,5 @@
 import {type Client, NetworkService, PaymentMethodType} from "@t-0/provider-sdk";
-import {toProtoDecimal} from "./lib";
+import {decimalFromString} from "./lib";
 import {randomUUID} from "node:crypto";
 
 export default async function submitPayment(networkClient: Client<typeof NetworkService>): Promise<void> {
@@ -11,7 +11,7 @@ export default async function submitPayment(networkClient: Client<typeof Network
     amount: {
       amount: {
         case: "payOutAmount",
-        value: toProtoDecimal(10, 0),
+        value: decimalFromString("10"),
       },
     },
     paymentDetails: {


### PR DESCRIPTION
## Summary

- Add exact, signed-int64-safe Decimal helpers to the Node starter and migrate starter examples.
- Export provider public-key derivation, preserve lowercase-only 0x parsing, and restore .env-first onboarding.
- Validate root and crypto package exports for ESM and CommonJS builds.
- Make local SDK tarball scaffolds and future Go module proxy verification release-safe.

## Validation

- Node SDK: 177 passing tests, including Node to Go cross-server tests.
- Node starter template: 8 passing tests.
- Canonical and generated Node scaffold tarball checks passed without manifest or top-level lockfile mutation.
- CLI generation, build, and tests passed.
- Disposable Linux amd64 Docker release lifecycle passed with Go 1.27.1 and Node 24.13.0/npm 11.6.2.

Closes #203