### PR TITLE
fix: prevent PROVIDER_PRIVATE_KEY leaking into Docker image layers

### DIFF
--- a/cli/internal/sync/main.go
+++ b/cli/internal/sync/main.go
@@ -189,7 +189,7 @@ func isTextFile(name string) bool {
 		return true
 	}
 	lower := strings.ToLower(name)
-	return lower == "dockerfile" || lower == "gradlew" || lower == "dot-gitignore" || lower == "makefile"
+	return lower == "dockerfile" || lower == "gradlew" || lower == "dot-gitignore" || lower == "dot-dockerignore" || lower == "makefile"
 }
 
 func findRepoRoot() (string, error) {

--- a/cli/scaffold.go
+++ b/cli/scaffold.go
@@ -183,6 +183,7 @@ func transformFilename(name, projectName, pascalName string) string {
 
 	// dot-gitignore → .gitignore (dotfiles stripped by Gradle/NuGet packaging)
 	name = strings.ReplaceAll(name, "dot-gitignore", ".gitignore")
+	name = strings.ReplaceAll(name, "dot-dockerignore", ".dockerignore")
 
 	// All templates use "my-provider" as the project name literal
 	name = strings.ReplaceAll(name, "my-provider", projectName)

--- a/cli/scaffold_test.go
+++ b/cli/scaffold_test.go
@@ -67,6 +67,16 @@ func TestScaffold_AllLanguages(t *testing.T) {
 			if _, err := os.Stat(filepath.Join(projectDir, "dot-gitignore")); err == nil {
 				t.Errorf("dot-gitignore still present in %s scaffold", lang)
 			}
+
+			// .dockerignore must exist for languages with Dockerfile-based workflows
+			if lang == "java" || lang == "csharp" || lang == "python" {
+				if _, err := os.Stat(filepath.Join(projectDir, ".dockerignore")); err != nil {
+					t.Errorf(".dockerignore missing in %s scaffold", lang)
+				}
+				if _, err := os.Stat(filepath.Join(projectDir, "dot-dockerignore")); err == nil {
+					t.Errorf("dot-dockerignore still present in %s scaffold", lang)
+				}
+			}
 		})
 	}
 }

--- a/csharp/starter/T0.ProviderStarter/Program.cs
+++ b/csharp/starter/T0.ProviderStarter/Program.cs
@@ -98,7 +98,8 @@ public static partial class Program
             var outputPath = relativePath
                 .Replace("my-provider", projectName)
                 .Replace("MyProvider", pascalName)
-                .Replace("dot-gitignore", ".gitignore");
+                .Replace("dot-gitignore", ".gitignore")
+                .Replace("dot-dockerignore", ".dockerignore");
 
             var filePath = Path.Combine(targetDir, outputPath);
             var dir = Path.GetDirectoryName(filePath);

--- a/csharp/starter/template/Dockerfile
+++ b/csharp/starter/template/Dockerfile
@@ -11,7 +11,6 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /app
 
 COPY --from=build /app .
-COPY .env* ./
 
 EXPOSE 8080
 

--- a/csharp/starter/template/dot-dockerignore
+++ b/csharp/starter/template/dot-dockerignore
@@ -1,0 +1,10 @@
+.env
+.env.*
+!.env.example
+.git/
+.gitignore
+.idea/
+.vscode/
+bin/
+obj/
+*.md

--- a/java/cli/src/main/java/network/t0/cli/TemplateExtractor.java
+++ b/java/cli/src/main/java/network/t0/cli/TemplateExtractor.java
@@ -77,7 +77,7 @@ public final class TemplateExtractor {
             try {
                 Path relativePath = source.relativize(sourcePath);
                 // Rename dot-gitignore to .gitignore (dotfiles are excluded by Gradle's default copy)
-                String relStr = relativePath.toString().replace("dot-gitignore", ".gitignore");
+                String relStr = relativePath.toString().replace("dot-gitignore", ".gitignore").replace("dot-dockerignore", ".dockerignore");
                 Path targetPath = target.resolve(relStr);
 
                 if (Files.isDirectory(sourcePath)) {
@@ -144,7 +144,8 @@ public final class TemplateExtractor {
             || lower.endsWith(".env")
             || lower.equals("gradlew")
             || lower.equals("dockerfile")
-            || lower.equals("dot-gitignore");
+            || lower.equals("dot-gitignore")
+            || lower.equals("dot-dockerignore");
     }
 
     private void makeExecutable(Path file) {

--- a/java/starter/template/Dockerfile
+++ b/java/starter/template/Dockerfile
@@ -25,9 +25,6 @@ WORKDIR /app
 # Copy the installed distribution (includes all dependencies)
 COPY --from=build /app/build/install/provider/ ./
 
-# Copy .env file if it exists (for local development)
-COPY .env* ./
-
 # Expose the provider server port
 EXPOSE 8080
 

--- a/java/starter/template/dot-dockerignore
+++ b/java/starter/template/dot-dockerignore
@@ -1,0 +1,10 @@
+.env
+.env.*
+!.env.example
+.git/
+.gitignore
+.idea/
+.vscode/
+build/
+.gradle/
+*.md

--- a/python/starter/src/t0_provider_starter/cli.py
+++ b/python/starter/src/t0_provider_starter/cli.py
@@ -67,6 +67,8 @@ def _copy_tree(src: Path, dst: Path, project_name: str) -> None:
             dest_name = dest_name.removesuffix(".template")
         if dest_name == "dot-gitignore":
             dest_name = ".gitignore"
+        if dest_name == "dot-dockerignore":
+            dest_name = ".dockerignore"
 
         dest_path = dst / dest_name
 

--- a/python/starter/src/t0_provider_starter/template/dot-dockerignore
+++ b/python/starter/src/t0_provider_starter/template/dot-dockerignore
@@ -1,0 +1,11 @@
+.env
+.env.*
+!.env.example
+.git/
+.gitignore
+.idea/
+.vscode/
+__pycache__/
+*.pyc
+.venv/
+*.md


### PR DESCRIPTION
## Summary

Closes #328.

- **Added `dot-dockerignore`** to Java, C#, and Python starter templates that excludes `.env*` (except `.env.example`), `.git/`, IDE dirs, and language-specific build artifacts
- **Removed `COPY .env*`** from Java and C# Dockerfiles — runtime config should come through `docker run --env-file .env` (already documented in READMEs)
- **Updated all four scaffolders** (Go CLI, Python CLI, Java CLI, C# starter) to rename `dot-dockerignore` → `.dockerignore`
- **Added `dot-dockerignore`** to text-file recognition in the sync tool and Java `TemplateExtractor`
- **Added test assertions** that `.dockerignore` exists and `dot-dockerignore` does not in Java/C#/Python scaffolds

Go and Node templates are unaffected — Go copies only the compiled binary, and Node already has a `.dockerignore` with selective COPYs.

## Test plan

- [x] `cd cli && go test ./...` — all scaffold tests pass including new `.dockerignore` assertions
- [x] `grep -r 'COPY .env' java/starter/template/Dockerfile csharp/starter/template/Dockerfile` — no matches
- [x] `cd java && ./gradlew :cli:build -x test` — BUILD SUCCESSFUL
- [x] `cd csharp/starter/T0.ProviderStarter && dotnet build` — Build succeeded
- [x] `cd python && uv sync --all-packages` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lg8EpJg5rgH6nxW99KqMP7