### PR TITLE
test: add KeyGenerator unit tests for C# starter

### DIFF
--- a/csharp/csharp.slnx
+++ b/csharp/csharp.slnx
@@ -5,5 +5,6 @@
   </Folder>
   <Folder Name="/starter/">
     <Project Path="starter/T0.ProviderStarter/T0.ProviderStarter.csproj" />
+    <Project Path="starter/T0.ProviderStarter.Tests/T0.ProviderStarter.Tests.csproj" />
   </Folder>
 </Solution>

--- a/csharp/starter/T0.ProviderStarter.Tests/KeyGeneratorTests.cs
+++ b/csharp/starter/T0.ProviderStarter.Tests/KeyGeneratorTests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using T0.ProviderStarter;
+
+namespace T0.ProviderStarter.Tests;
+
+public class KeyGeneratorTests
+{
+    private static readonly JsonDocument Vectors = LoadVectors();
+
+    private static JsonDocument LoadVectors()
+    {
+        var testDir = AppContext.BaseDirectory;
+        var repoRoot = Path.GetFullPath(Path.Combine(testDir, "..", "..", "..", "..", "..", ".."));
+        var vectorsPath = Path.Combine(repoRoot, "cross_test", "test_vectors.json");
+        var json = File.ReadAllText(vectorsPath);
+        return JsonDocument.Parse(json);
+    }
+
+    [Fact]
+    public void DerivePublicKey_ShouldMatchTestVector()
+    {
+        var keys = Vectors.RootElement.GetProperty("keys");
+        var privateKeyHex = keys.GetProperty("private_key").GetString()!;
+        var expectedPublicKeyHex = keys.GetProperty("public_key").GetString()!;
+
+        var actualPublicKeyHex = KeyGenerator.DerivePublicKeyHex(privateKeyHex);
+
+        Assert.Equal(expectedPublicKeyHex, actualPublicKeyHex);
+    }
+
+    [Fact]
+    public void DerivePublicKey_ShouldMatchImpostorVector()
+    {
+        var keys = Vectors.RootElement.GetProperty("impostor_keys");
+        var privateKeyHex = keys.GetProperty("private_key").GetString()!;
+        var expectedPublicKeyHex = keys.GetProperty("public_key").GetString()!;
+
+        var actualPublicKeyHex = KeyGenerator.DerivePublicKeyHex(privateKeyHex);
+
+        Assert.Equal(expectedPublicKeyHex, actualPublicKeyHex);
+    }
+
+    [Fact]
+    public void Generate_ShouldProduceValidKeyStructure()
+    {
+        var (privateKeyHex, publicKeyHex) = KeyGenerator.Generate();
+
+        // Private key: 32 bytes = 64 hex chars
+        Assert.Equal(64, privateKeyHex.Length);
+        Assert.True(privateKeyHex.All(c => "0123456789abcdef".Contains(c)));
+
+        // Public key: 65 bytes = 130 hex chars, starts with "04" (uncompressed)
+        Assert.Equal(130, publicKeyHex.Length);
+        Assert.StartsWith("04", publicKeyHex);
+        Assert.True(publicKeyHex.All(c => "0123456789abcdef".Contains(c)));
+    }
+
+    [Fact]
+    public void Generate_ShouldProduceConsistentKeypair()
+    {
+        var (privateKeyHex, publicKeyHex) = KeyGenerator.Generate();
+
+        // Re-derive public key from the private key — must match
+        var reDerived = KeyGenerator.DerivePublicKeyHex(privateKeyHex);
+        Assert.Equal(publicKeyHex, reDerived);
+    }
+
+    [Fact]
+    public void Generate_ShouldProduceUniqueKeys()
+    {
+        var (priv1, _) = KeyGenerator.Generate();
+        var (priv2, _) = KeyGenerator.Generate();
+
+        Assert.NotEqual(priv1, priv2);
+    }
+}

--- a/csharp/starter/T0.ProviderStarter.Tests/T0.ProviderStarter.Tests.csproj
+++ b/csharp/starter/T0.ProviderStarter.Tests/T0.ProviderStarter.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\T0.ProviderStarter\T0.ProviderStarter.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/csharp/starter/T0.ProviderStarter/KeyGenerator.cs
+++ b/csharp/starter/T0.ProviderStarter/KeyGenerator.cs
@@ -27,13 +27,20 @@ public static class KeyGenerator
             privateKeyInt = new BigInteger(1, privateKeyBytes);
         } while (privateKeyInt.CompareTo(BigInteger.One) <= 0 || privateKeyInt.CompareTo(Domain.N) >= 0);
 
-        // Derive uncompressed public key
-        var publicKeyPoint = Domain.G.Multiply(privateKeyInt).Normalize();
-        var publicKeyBytes = publicKeyPoint.GetEncoded(false); // false = uncompressed (65 bytes)
+        var privateKeyHex = Convert.ToHexString(privateKeyBytes).ToLowerInvariant();
+        return (privateKeyHex, DerivePublicKeyHex(privateKeyHex));
+    }
 
-        return (
-            Convert.ToHexString(privateKeyBytes).ToLowerInvariant(),
-            Convert.ToHexString(publicKeyBytes).ToLowerInvariant()
-        );
+    /// <summary>
+    /// Derives the uncompressed secp256k1 public key (65 bytes, 0x04 prefix)
+    /// from a hex-encoded private key.
+    /// </summary>
+    public static string DerivePublicKeyHex(string privateKeyHex)
+    {
+        var privateKeyBytes = Convert.FromHexString(privateKeyHex);
+        var privateKeyInt = new BigInteger(1, privateKeyBytes);
+        var publicKeyPoint = Domain.G.Multiply(privateKeyInt).Normalize();
+        var publicKeyBytes = publicKeyPoint.GetEncoded(false);
+        return Convert.ToHexString(publicKeyBytes).ToLowerInvariant();
     }
 }

--- a/csharp/starter/T0.ProviderStarter/T0.ProviderStarter.csproj
+++ b/csharp/starter/T0.ProviderStarter/T0.ProviderStarter.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/t-0-network/provider-sdk</RepositoryUrl>
   </PropertyGroup>
 
-<ItemGroup>
+  <ItemGroup>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Extracts `DerivePublicKeyHex` from `KeyGenerator` for deterministic testing
- Adds `T0.ProviderStarter.Tests` project with 5 tests:
  - Key derivation against cross-language test vectors (keys + impostor_keys)
  - Generated key structure validation (lengths, 04 prefix)
  - Generated keypair consistency (re-derivation matches)
  - Uniqueness of generated keys
- Required by Tier 3 crypto audit for #349 (BouncyCastle 2.6.2 → 2.7.0)

## Test plan
- [x] `dotnet test` passes all 5 tests
- [x] Cross-language test vectors match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9e8zdfyjheGD8s5ggdvS