### PR TITLE
chore(deps): bump grpc and nmcp.aggregation (Java)

### DIFF
--- a/java/sdk/build.gradle.kts
+++ b/java/sdk/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.gradleup.nmcp")
 }
 
-val grpcVersion = "1.83.1"
+val grpcVersion = "1.84.0"
 val protobufVersion = "4.36.1"
 val bouncyCastleVersion = "1.85.2"
 

--- a/java/settings.gradle.kts
+++ b/java/settings.gradle.kts
@@ -5,7 +5,7 @@ pluginManagement {
     }
     plugins {
         id("com.gradleup.nmcp") version "1.6.2"
-        id("com.gradleup.nmcp.aggregation") version "1.6.1"
+        id("com.gradleup.nmcp.aggregation") version "1.6.2"
     }
 }
 


### PR DESCRIPTION
## Summary
- Bumps `io.grpc` from `1.83.1` to `1.84.0` (includes netty stream-limit CVE-2026-47244 fix)
- Bumps `com.gradleup.nmcp.aggregation` from `1.6.1` to `1.6.2` (publish-path plugin patch)

Supersedes #339 and #334 — those Dependabot PRs conflict with master after earlier deps in the same file-groups merged (#348, #342), and cannot be rebased (Dependabot config entries deleted by #351).

## Test plan
- [x] `./gradlew build` passes (includes `ValidationTest`, cross-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq9e8zdfyjheGD8s5ggdvS